### PR TITLE
修复codex兔子线路的API请求地址

### DIFF
--- a/src-tauri/src/database/dao/providers_seed.rs
+++ b/src-tauri/src/database/dao/providers_seed.rs
@@ -20,7 +20,7 @@ pub(crate) const CODEX_OFFICIAL_PROVIDER_IDS: &[(&str, &str, &str, &str, &str)] 
         "tuzi-route",
         "兔子线路",
         "https://api.tu-zi.com",
-        "https://api.tu-zi.com",
+        "https://api.tu-zi.com/v1",
         "gpt-5.5",
     ),
     (

--- a/src/components/providers/EditProviderDialog.tsx
+++ b/src/components/providers/EditProviderDialog.tsx
@@ -9,6 +9,10 @@ import {
   type ProviderFormValues,
 } from "@/components/providers/forms/ProviderForm";
 import { openclawApi, providersApi, vscodeApi, type AppId } from "@/lib/api";
+import {
+  extractCodexBaseUrl,
+  setCodexBaseUrl as setCodexBaseUrlInConfig,
+} from "@/utils/providerConfigUtils";
 
 interface EditProviderDialogProps {
   open: boolean;
@@ -150,8 +154,18 @@ export function EditProviderDialog({
         };
       }
     }
+    if (appId === "codex" && provider?.name === "兔子线路") {
+      const configStr = typeof config.config === "string" ? config.config : "";
+      const existingUrl = extractCodexBaseUrl(configStr);
+      if (!existingUrl || !existingUrl.endsWith("/v1")) {
+        config.config = setCodexBaseUrlInConfig(
+          configStr,
+          "https://api.tu-zi.com/v1",
+        );
+      }
+    }
     return config;
-  }, [appId, liveSettings, provider?.settingsConfig]); // 只依赖 settingsConfig，不依赖整个 provider
+  }, [appId, liveSettings, provider?.name, provider?.settingsConfig]); // 只依赖 settingsConfig，不依赖整个 provider
 
   // 固定 initialData，防止 provider 对象更新时重置表单
   const initialData = useMemo(() => {

--- a/src/components/providers/forms/hooks/useCodexConfigState.ts
+++ b/src/components/providers/forms/hooks/useCodexConfigState.ts
@@ -9,6 +9,7 @@ import { normalizeTomlText } from "@/utils/textNormalization";
 
 interface UseCodexConfigStateProps {
   initialData?: {
+    name?: string;
     settingsConfig?: Record<string, unknown>;
   };
 }
@@ -49,6 +50,8 @@ export function useCodexConfigState({ initialData }: UseCodexConfigStateProps) {
       const initialBaseUrl = extractCodexBaseUrl(configStr);
       if (initialBaseUrl) {
         setCodexBaseUrl(initialBaseUrl);
+      } else if (initialData?.name === "兔子线路") {
+        setCodexBaseUrl("https://api.tu-zi.com/v1");
       }
 
       // 提取 Model Name

--- a/src/config/codexProviderPresets.ts
+++ b/src/config/codexProviderPresets.ts
@@ -68,11 +68,11 @@ export const codexProviderPresets: CodexProviderPreset[] = [
     auth: { OPENAI_API_KEY: "" },
     config: generateThirdPartyConfig(
       "tuzi_route",
-      "https://api.tu-zi.com",
+      "https://api.tu-zi.com/v1",
       "gpt-5.5",
     ),
     category: "aggregator",
-    endpointCandidates: ["https://api.tu-zi.com"],
+    endpointCandidates: ["https://api.tu-zi.com/v1"],
     icon: "tuzi",
     theme: { icon: "tuzi" },
   },

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -804,7 +804,7 @@
     "websiteUrlPlaceholder": "https://example.com (optional)",
     "apiEndpoint": "API Endpoint",
     "apiEndpointPlaceholder": "https://your-api-endpoint.com",
-    "codexApiEndpointPlaceholder": "https://your-api-endpoint.com/v1",
+    "codexApiEndpointPlaceholder": "https://api.tu-zi.com/v1",
     "manageAndTest": "Manage & Test",
     "configContent": "Config Content",
     "officialNoApiKey": "Official login does not require API Key, save directly",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -804,7 +804,7 @@
     "websiteUrlPlaceholder": "https://example.com（任意）",
     "apiEndpoint": "API エンドポイント",
     "apiEndpointPlaceholder": "https://your-api-endpoint.com",
-    "codexApiEndpointPlaceholder": "https://your-api-endpoint.com/v1",
+    "codexApiEndpointPlaceholder": "https://api.tu-zi.com/v1",
     "manageAndTest": "管理・テスト",
     "configContent": "設定内容",
     "officialNoApiKey": "公式ログインは API Key 不要です。そのまま保存できます",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -804,7 +804,7 @@
     "websiteUrlPlaceholder": "https://example.com（可选）",
     "apiEndpoint": "请求地址",
     "apiEndpointPlaceholder": "https://your-api-endpoint.com",
-    "codexApiEndpointPlaceholder": "https://your-api-endpoint.com/v1",
+    "codexApiEndpointPlaceholder": "https://api.tu-zi.com/v1",
     "manageAndTest": "管理与测速",
     "configContent": "配置内容",
     "officialNoApiKey": "官方登录无需填写 API Key，直接保存即可",


### PR DESCRIPTION
修复 Codex 兔子线路供应商的 API 请求地址缺少 /v1 路径的问题。

## 变更内容

- **codexProviderPresets**: 兔子线路预设 base_url 补全 `/v1` 路径，endpointCandidates 同步更新
- **providers_seed**: Rust 种子数据 base_url 从 `https://api.tu-zi.com` 更新为 `https://api.tu-zi.com/v1`
- **EditProviderDialog**: 编辑已有兔子线路供应商时，若地址不含 `/v1` 自动修正
- **useCodexConfigState**: 无 base_url 时回退默认值为 `https://api.tu-zi.com/v1`
- **i18n (zh/en/ja)**: 端点输入框占位符更新为 `https://api.tu-zi.com/v1`