### PR TITLE
fix: 修复 Codex env_key 与 base_url 串线

### DIFF
--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -1081,15 +1081,15 @@ fn restore_codex_provider_token_for_backfill_with_env_writer(
 
     if let Some(obj) = settings.as_object_mut() {
         let env_key = template_settings
-            .get("env")
-            .and_then(|env| env.get("envKey"))
+            .get("config")
             .and_then(Value::as_str)
-            .map(str::to_string)
+            .and_then(extract_codex_env_key)
             .or_else(|| {
                 template_settings
-                    .get("config")
+                    .get("env")
+                    .and_then(|env| env.get("envKey"))
                     .and_then(Value::as_str)
-                    .and_then(extract_codex_env_key)
+                    .map(str::to_string)
             });
         if let Some(env_key) = env_key.as_deref() {
             write_env_key(env_key, &token)?;
@@ -2078,7 +2078,7 @@ experimental_bearer_token = "sk-backfill"
         });
         let template_settings = json!({
             "auth": {},
-            "env": { "envKey": "TUZI_BACKFILL_CODEX_API_KEY" },
+            "env": { "envKey": "STALE_CODEX_API_KEY" },
             "config": r#"model_provider = "vendor_alpha"
 
 [model_providers.vendor_alpha]

--- a/src/components/providers/ProviderCard.tsx
+++ b/src/components/providers/ProviderCard.tsx
@@ -21,7 +21,7 @@ import { ProviderHealthBadge } from "@/components/providers/ProviderHealthBadge"
 import { FailoverPriorityBadge } from "@/components/providers/FailoverPriorityBadge";
 import {
   extractCodexBaseUrl,
-  getCodexEnvKey,
+  getCodexProviderEnvKeyFromSettings,
 } from "@/utils/providerConfigUtils";
 import { useProviderHealth } from "@/lib/query/failover";
 import { useUsageQuery } from "@/lib/query/queries";
@@ -76,9 +76,9 @@ function isOfficialProvider(provider: Provider, appId: AppId): boolean {
     return !baseUrl || (typeof baseUrl === "string" && baseUrl.trim() === "");
   }
   if (appId === "codex") {
-    // 无 OPENAI_API_KEY 且无 env.envKey → 使用 Codex CLI 内置 OAuth（官方）
+    // 无 OPENAI_API_KEY 且无有效 env_key → 使用 Codex CLI 内置 OAuth（官方）
     const apiKey = config?.auth?.OPENAI_API_KEY;
-    const envKey = config?.env?.envKey;
+    const envKey = getCodexProviderEnvKeyFromSettings(provider.settingsConfig);
     return (!apiKey || (typeof apiKey === "string" && apiKey.trim() === "")) && !envKey;
   }
   if (appId === "gemini") {
@@ -193,15 +193,9 @@ export function ProviderCard({
       setEnvKeyValue(null);
       return;
     }
-    let cfg = provider.settingsConfig as any;
-    if (typeof cfg === "string") {
-      try { cfg = JSON.parse(cfg); } catch { return; }
-    }
-    let envKeyName = cfg?.env?.envKey;
-    if (!envKeyName) {
-      const configStr = typeof cfg?.config === "string" ? cfg.config : "";
-      envKeyName = getCodexEnvKey(configStr) ?? undefined;
-    }
+    const envKeyName = getCodexProviderEnvKeyFromSettings(
+      provider.settingsConfig,
+    );
     if (!envKeyName) {
       setEnvKeyValue(null);
       return;

--- a/src/components/providers/ProviderList.tsx
+++ b/src/components/providers/ProviderList.tsx
@@ -50,7 +50,7 @@ import { ConfirmDialog } from "@/components/ConfirmDialog";
 import { settingsApi } from "@/lib/api/settings";
 import {
   getApiKeyFromConfig,
-  getCodexEnvKey,
+  getCodexProviderEnvKeyFromSettings,
 } from "@/utils/providerConfigUtils";
 
 interface ProviderListProps {
@@ -237,22 +237,7 @@ export function ProviderList({
   );
 
   const getCodexProviderEnvKey = useCallback((provider: Provider) => {
-    let cfg = provider.settingsConfig;
-    if (typeof cfg === "string") {
-      try {
-        cfg = JSON.parse(cfg);
-      } catch {
-        return "";
-      }
-    }
-
-    const envKey = cfg?.env?.envKey;
-    if (typeof envKey === "string" && envKey.trim()) {
-      return envKey.trim();
-    }
-
-    const configText = typeof cfg?.config === "string" ? cfg.config : "";
-    return getCodexEnvKey(configText) ?? "";
+    return getCodexProviderEnvKeyFromSettings(provider.settingsConfig);
   }, []);
 
   const hasOpenCodeApiKey = (provider: Provider): boolean => {

--- a/src/components/providers/forms/ProviderForm.tsx
+++ b/src/components/providers/forms/ProviderForm.tsx
@@ -69,6 +69,7 @@ import type { UniversalProviderPreset } from "@/config/universalProviderPresets"
 import {
   applyTemplateValues,
   extractCodexWireApi,
+  getCodexProviderEnvKeyFromSettings,
   hasApiKeyField,
   setCodexModelName as setCodexModelNameInConfig,
   setCodexWireApi,
@@ -1297,12 +1298,17 @@ function ProviderFormFull({
           /^\s*model_provider\s*=\s*"([^"]+)"/m,
         );
         const routeId = routeIdMatch?.[1] || "tuziswitch";
+        const resolvedCodexEnvKey =
+          getCodexProviderEnvKeyFromSettings({
+            config: normalizedCodexConfig,
+            env: { envKey: codexEnvKey },
+          }) || codexEnvKey;
 
-        if (codexEnvKey && codexBaseUrl) {
+        if (resolvedCodexEnvKey && codexBaseUrl) {
           await invoke("save_codex_route", {
             routeId,
             baseUrl: codexBaseUrl,
-            envKey: codexEnvKey,
+            envKey: resolvedCodexEnvKey,
             apiKey: codexApiKey || "",
             model:
               normalizedCatalogModels[0]?.model || codexModelName || "gpt-5.5",
@@ -1318,7 +1324,7 @@ function ProviderFormFull({
         } = {
           auth: {},
           config: normalizedCodexConfig,
-          env: { envKey: codexEnvKey },
+          env: { envKey: resolvedCodexEnvKey },
         };
         if (normalizedCatalogModels.length > 0) {
           configObj.modelCatalog = { models: normalizedCatalogModels };
@@ -1331,7 +1337,13 @@ function ProviderFormFull({
         settingsConfig = JSON.stringify({
           auth: {},
           config: fallbackConfig,
-          env: { envKey: codexEnvKey },
+          env: {
+            envKey:
+              getCodexProviderEnvKeyFromSettings({
+                config: fallbackConfig,
+                env: { envKey: codexEnvKey },
+              }) || codexEnvKey,
+          },
         });
       }
     } else if (appId === "gemini") {
@@ -1707,12 +1719,9 @@ function ProviderFormFull({
               );
             if (!nameMatches) return false;
             // Check if actually configured: env_key exists AND has value in shell rc
-            const cfg = p.settingsConfig as Record<string, any>;
-            const envKeyName =
-              cfg?.env?.envKey ||
-              (typeof cfg?.config === "string"
-                ? cfg.config.match(/env_key\s*=\s*"([^"]+)"/)?.[1]
-                : undefined);
+            const envKeyName = getCodexProviderEnvKeyFromSettings(
+              p.settingsConfig,
+            );
             if (!envKeyName) return false;
             return Boolean(shellEnvKeys?.[envKeyName]);
           },

--- a/src/components/providers/forms/hooks/useCodexConfigState.ts
+++ b/src/components/providers/forms/hooks/useCodexConfigState.ts
@@ -5,6 +5,7 @@ import {
   extractCodexModelName,
   setCodexModelName as setCodexModelNameInConfig,
   getCodexEnvKey,
+  getCodexProviderEnvKeyFromSettings,
 } from "@/utils/providerConfigUtils";
 import { normalizeTomlText } from "@/utils/textNormalization";
 import { invoke } from "@tauri-apps/api/core";
@@ -174,11 +175,10 @@ export function useCodexConfigState({ initialData }: UseCodexConfigStateProps) {
       const initialModelName = extractCodexModelName(configStr);
       if (initialModelName) setCodexModelName(initialModelName);
 
-      // Determine envKey: from env field or from TOML config
-      const envObj = (config as any).env;
-      const envKeyFromField = envObj?.envKey;
-      const envKeyFromToml = getCodexEnvKey(configStr);
-      const resolvedEnvKey = envKeyFromField || envKeyFromToml || "";
+      // TOML is the source of truth. The legacy env.envKey field is only a fallback.
+      const resolvedEnvKey =
+        getCodexProviderEnvKeyFromSettings({ ...config, config: configStr }) ||
+        "";
       setCodexEnvKey(resolvedEnvKey);
 
       // Read API key from shell rc via backend
@@ -300,8 +300,8 @@ export function useCodexConfigState({ initialData }: UseCodexConfigStateProps) {
           setCodexModelName(extractedModel);
       }
       // Sync env_key from config
-      const newEnvKey = getCodexEnvKey(normalized);
-      if (newEnvKey && newEnvKey !== codexEnvKey) setCodexEnvKey(newEnvKey);
+      const newEnvKey = getCodexEnvKey(normalized) || "";
+      if (newEnvKey !== codexEnvKey) setCodexEnvKey(newEnvKey);
     },
     [setCodexConfig, codexBaseUrl, codexModelName, codexEnvKey],
   );
@@ -321,7 +321,10 @@ export function useCodexConfigState({ initialData }: UseCodexConfigStateProps) {
       else setCodexModelName("");
       setCodexCatalogModels([]);
 
-      const resolvedEnvKey = envKey || getCodexEnvKey(config) || "";
+      const resolvedEnvKey = getCodexProviderEnvKeyFromSettings({
+        config,
+        env: { envKey },
+      });
       setCodexEnvKey(resolvedEnvKey);
 
       // Don't pre-fill key on preset switch (new mode) — user should enter their own key

--- a/src/utils/providerConfigUtils.ts
+++ b/src/utils/providerConfigUtils.ts
@@ -1404,3 +1404,37 @@ export const getCodexEnvKey = (configText: string): string | null => {
 
   return null;
 };
+
+export const getCodexProviderEnvKeyFromSettings = (
+  settingsConfig: unknown,
+): string => {
+  let cfg = settingsConfig;
+  if (typeof cfg === "string") {
+    try {
+      cfg = JSON.parse(cfg);
+    } catch {
+      return "";
+    }
+  }
+
+  if (!cfg || typeof cfg !== "object") {
+    return "";
+  }
+
+  const configText =
+    typeof (cfg as Record<string, unknown>).config === "string"
+      ? ((cfg as Record<string, unknown>).config as string)
+      : "";
+  const envKeyFromToml = getCodexEnvKey(configText);
+  if (envKeyFromToml?.trim()) {
+    return envKeyFromToml.trim();
+  }
+
+  const envObj = (cfg as Record<string, unknown>).env;
+  if (!envObj || typeof envObj !== "object") {
+    return "";
+  }
+
+  const envKey = (envObj as Record<string, unknown>).envKey;
+  return typeof envKey === "string" ? envKey.trim() : "";
+};

--- a/tests/utils/providerConfigUtils.codex.test.ts
+++ b/tests/utils/providerConfigUtils.codex.test.ts
@@ -3,6 +3,7 @@ import {
   extractCodexBaseUrl,
   extractCodexExperimentalBearerToken,
   getCodexEnvKey,
+  getCodexProviderEnvKeyFromSettings,
   extractCodexModelCatalogJson,
   extractCodexModelName,
   extractCodexWireApi,
@@ -42,6 +43,28 @@ describe("Codex TOML utils", () => {
         ].join("\n"),
       ),
     ).toBe("LEGACY_API_KEY");
+  });
+
+  it("prefers the active provider TOML env_key over legacy settings envKey", () => {
+    const config = [
+      'model_provider = "tuzi"',
+      "",
+      "[model_providers.tuzi]",
+      'base_url = "https://tuzi.example/v1"',
+      'env_key = "TUZI_CODEX_KEY"',
+      "",
+      "[model_providers.other]",
+      'base_url = "https://other.example/v1"',
+      'env_key = "OTHER_CODEX_KEY"',
+      "",
+    ].join("\n");
+
+    expect(
+      getCodexProviderEnvKeyFromSettings({
+        config,
+        env: { envKey: "STALE_CODEX_KEY" },
+      }),
+    ).toBe("TUZI_CODEX_KEY");
   });
 
   it("removes base_url line when set to empty", () => {


### PR DESCRIPTION
## 问题描述
Codex Provider 编辑、列表展示和保存链路中，部分逻辑优先读取 `settingsConfig.env.envKey`，会让旧 envKey 覆盖 `config.toml` 当前 `[model_providers.<model_provider>]` 段的 `env_key`。结果是 `base_url` 来自 A provider，但 API Key 来自 B provider。

## 修复思路
- 统一新增 `getCodexProviderEnvKeyFromSettings`，以当前 TOML active provider 段的 `env_key` 为准。
- `settingsConfig.env.envKey` 仅作为旧数据 fallback。
- 保存前重新从规范化后的 TOML 解析 envKey，避免旧字段回写污染。
- Rust backfill 迁移同样改为 active TOML `env_key` 优先。

## 更新代码架构
- 前端编辑页、列表卡片、缺 Key 判断、预设后缀统计、保存链路统一复用新的 envKey 解析入口。
- Rust backfill 复用 active provider env_key 解析，避免迁移时写错环境变量。
- 增加回归测试覆盖旧 `env.envKey` 不应覆盖 TOML active `env_key`。

## 验证
- `pnpm vitest run tests/utils/providerConfigUtils.codex.test.ts`
- `pnpm typecheck`
- `cargo test codex_config --lib`