### PR TITLE
修复同 Key 查询继承父级 Base URL

### DIFF
--- a/src-tauri/src/services/provider/live.rs
+++ b/src-tauri/src/services/provider/live.rs
@@ -62,6 +62,47 @@ fn codex_active_provider_string_field(config_text: &str, field: &str) -> Option<
         .map(ToString::to_string)
 }
 
+fn codex_inherited_base_url_by_env_key(config_text: &str) -> Option<String> {
+    let doc = codex_config_doc(config_text)?;
+    let route_id = doc
+        .get("model_provider")
+        .and_then(|item| item.as_str())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())?;
+
+    let providers = doc.get("model_providers")?.as_table()?;
+    let target_env_key = providers
+        .get(route_id)
+        .and_then(|item| item.as_table())
+        .and_then(|table| table.get("env_key"))
+        .and_then(|item| item.as_str())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())?;
+
+    let inherited = providers.iter().find_map(|(provider_id, item)| {
+        if provider_id == route_id {
+            return None;
+        }
+        let table = item.as_table()?;
+        let env_key = table
+            .get("env_key")
+            .and_then(|value| value.as_str())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())?;
+        if env_key != target_env_key {
+            return None;
+        }
+        table
+            .get("base_url")
+            .and_then(|value| value.as_str())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToString::to_string)
+    });
+
+    inherited
+}
+
 pub(crate) fn sanitize_claude_settings_for_live(settings: &Value) -> Value {
     let mut v = settings.clone();
     if let Some(obj) = v.as_object_mut() {
@@ -803,8 +844,9 @@ pub(crate) fn write_live_snapshot(app_type: &AppType, provider: &Provider) -> Re
             let effort = codex_top_level_string_field(config_str, "model_reasoning_effort")
                 .unwrap_or_else(|| "high".to_string());
 
-            let base_url =
-                codex_active_provider_string_field(config_str, "base_url").unwrap_or_default();
+            let base_url = codex_active_provider_string_field(config_str, "base_url")
+                .or_else(|| codex_inherited_base_url_by_env_key(config_str))
+                .unwrap_or_default();
 
             let config_with_route =
                 save_route_to_config(&existing, &route_id, &base_url, &env_key, &model, &effort)?;
@@ -814,8 +856,12 @@ pub(crate) fn write_live_snapshot(app_type: &AppType, provider: &Provider) -> Re
                 switch_codex_profile(&config_with_route, &route_id, Some(&model), Some(&effort))?;
 
             // Restore experimental_bearer_token if it exists in the provider's config
-            if let Some(token) = crate::codex_config::extract_codex_experimental_bearer_token(config_str) {
-                if let Ok(updated) = crate::codex_config::set_codex_experimental_bearer_token(&final_config, &token) {
+            if let Some(token) =
+                crate::codex_config::extract_codex_experimental_bearer_token(config_str)
+            {
+                if let Ok(updated) =
+                    crate::codex_config::set_codex_experimental_bearer_token(&final_config, &token)
+                {
                     final_config = updated;
                 }
             }
@@ -1639,6 +1685,31 @@ mod tests {
         let stripped =
             remove_common_config_from_settings(&AppType::Codex, &applied, snippet).unwrap();
         assert_eq!(stripped, settings);
+    }
+
+    #[test]
+    fn codex_base_url_inherits_from_same_env_key_provider() {
+        let config = r#"model_provider = "child"
+model = "gpt-5.5"
+
+[model_providers.parent]
+name = "parent"
+base_url = "https://parent.example/v1"
+env_key = "SHARED_CODEX_KEY"
+wire_api = "responses"
+
+[model_providers.child]
+name = "child"
+env_key = "SHARED_CODEX_KEY"
+wire_api = "responses"
+"#;
+
+        assert_eq!(
+            codex_active_provider_string_field(config, "base_url")
+                .or_else(|| codex_inherited_base_url_by_env_key(config))
+                .as_deref(),
+            Some("https://parent.example/v1")
+        );
     }
 
     #[test]

--- a/src/components/providers/ProviderCard.tsx
+++ b/src/components/providers/ProviderCard.tsx
@@ -36,6 +36,7 @@ interface ProviderCardProps {
   provider: Provider;
   isCurrent: boolean;
   appId: AppId;
+  resolvedQueryUrl?: string;
   isInConfig?: boolean; // OpenCode: 是否已添加到 opencode.json
   isOmo?: boolean;
   isOmoSlim?: boolean;
@@ -132,6 +133,7 @@ export function ProviderCard({
   provider,
   isCurrent,
   appId,
+  resolvedQueryUrl,
   isInConfig = true,
   isOmo = false,
   isOmoSlim = false,
@@ -173,8 +175,8 @@ export function ProviderCard({
   });
 
   const displayUrl = useMemo(() => {
-    return extractApiUrl(provider, fallbackUrlText);
-  }, [provider, fallbackUrlText]);
+    return resolvedQueryUrl || extractApiUrl(provider, fallbackUrlText);
+  }, [provider, fallbackUrlText, resolvedQueryUrl]);
 
   const isClickableUrl = useMemo(() => {
     if (provider.notes?.trim()) {

--- a/src/components/providers/ProviderList.tsx
+++ b/src/components/providers/ProviderList.tsx
@@ -49,6 +49,7 @@ import { Button } from "@/components/ui/button";
 import { ConfirmDialog } from "@/components/ConfirmDialog";
 import { settingsApi } from "@/lib/api/settings";
 import {
+  extractCodexBaseUrl,
   getApiKeyFromConfig,
   getCodexProviderEnvKeyFromSettings,
 } from "@/utils/providerConfigUtils";
@@ -74,6 +75,48 @@ interface ProviderListProps {
   activeProviderId?: string; // 代理当前实际使用的供应商 ID（用于故障转移模式下标注绿色边框）
   onSetAsDefault?: (provider: Provider) => void; // OpenClaw: set as default model
 }
+
+const normalizeProviderUrl = (rawUrl?: string): string => {
+  const url = rawUrl?.trim().replace(/\/+$/, "") ?? "";
+  return url.startsWith("http") ? url : "";
+};
+
+const getProviderBaseUrl = (provider: Provider, appId: AppId): string => {
+  const config = provider.settingsConfig as Record<string, any>;
+  if (appId === "claude") {
+    return normalizeProviderUrl(config?.env?.ANTHROPIC_BASE_URL);
+  }
+  if (appId === "gemini") {
+    return normalizeProviderUrl(config?.env?.GOOGLE_GEMINI_BASE_URL);
+  }
+  if (appId === "codex") {
+    return normalizeProviderUrl(
+      typeof config?.config === "string"
+        ? extractCodexBaseUrl(config.config)
+        : undefined,
+    );
+  }
+  return "";
+};
+
+const getProviderPlainApiKey = (
+  provider: Provider,
+  appId: AppId,
+  codexEnvKeys: Record<string, string>,
+): string => {
+  if (appId === "codex") {
+    const envKeyName = getCodexProviderEnvKeyFromSettings(
+      provider.settingsConfig,
+    );
+    const envKeyValue = envKeyName ? codexEnvKeys[envKeyName] : "";
+    if (envKeyValue?.trim()) return envKeyValue.trim();
+  }
+
+  return getApiKeyFromConfig(
+    JSON.stringify(provider.settingsConfig ?? {}),
+    appId,
+  ).trim();
+};
 
 export function ProviderList({
   providers,
@@ -129,6 +172,29 @@ export function ProviderList({
       .then((keys) => setCodexEnvKeys(keys))
       .catch(() => setCodexEnvKeys({}));
   }, [appId, providers, currentProviderId]);
+
+  const queryUrlByProviderId = useMemo(() => {
+    if (appId !== "claude" && appId !== "codex" && appId !== "gemini") {
+      return {};
+    }
+
+    const baseUrlByApiKey = new Map<string, string>();
+    const providerEntries = sortedProviders.map((provider) => {
+      const apiKey = getProviderPlainApiKey(provider, appId, codexEnvKeys);
+      const baseUrl = getProviderBaseUrl(provider, appId);
+      if (apiKey && baseUrl && !baseUrlByApiKey.has(apiKey)) {
+        baseUrlByApiKey.set(apiKey, baseUrl);
+      }
+      return { provider, apiKey, baseUrl };
+    });
+
+    return Object.fromEntries(
+      providerEntries.map(({ provider, apiKey, baseUrl }) => [
+        provider.id,
+        apiKey ? (baseUrlByApiKey.get(apiKey) ?? baseUrl) : baseUrl,
+      ]),
+    );
+  }, [appId, codexEnvKeys, sortedProviders]);
 
   // 判断供应商是否已添加到配置（累加模式应用：OpenCode/OpenClaw/Hermes）
   const isProviderInConfig = useCallback(
@@ -539,6 +605,7 @@ export function ProviderList({
                         : provider.id === currentProviderId
                 }
                 appId={appId}
+                resolvedQueryUrl={queryUrlByProviderId[provider.id]}
                 isInConfig={isProviderInConfig(provider.id)}
                 isOmo={isOmo}
                 isOmoSlim={isOmoSlim}
@@ -707,6 +774,7 @@ interface SortableProviderCardProps {
   provider: Provider;
   isCurrent: boolean;
   appId: AppId;
+  resolvedQueryUrl?: string;
   isInConfig: boolean;
   isOmo: boolean;
   isOmoSlim: boolean;
@@ -738,6 +806,7 @@ function SortableProviderCard({
   provider,
   isCurrent,
   appId,
+  resolvedQueryUrl,
   isInConfig,
   isOmo,
   isOmoSlim,
@@ -783,6 +852,7 @@ function SortableProviderCard({
         provider={provider}
         isCurrent={isCurrent}
         appId={appId}
+        resolvedQueryUrl={resolvedQueryUrl}
         isInConfig={isInConfig}
         isOmo={isOmo}
         isOmoSlim={isOmoSlim}

--- a/src/utils/providerConfigUtils.ts
+++ b/src/utils/providerConfigUtils.ts
@@ -488,6 +488,13 @@ interface TomlAssignmentMatch {
   value: string;
 }
 
+interface CodexModelProviderSection {
+  baseUrl?: string;
+  envKey?: string;
+  headerIndex: number;
+  sectionName: string;
+}
+
 const finalizeTomlText = (lines: string[]): string =>
   lines
     .join("\n")
@@ -689,6 +696,76 @@ const getRecoverableBaseUrlAssignments = (
       !isOtherProviderSection(sectionName, targetSectionName),
   );
 
+const getCodexModelProviderSections = (
+  lines: string[],
+): CodexModelProviderSection[] => {
+  const sections: CodexModelProviderSection[] = [];
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const match = lines[index].match(TOML_SECTION_HEADER_PATTERN);
+    const sectionName = match?.[1];
+    if (!sectionName?.startsWith("model_providers.")) {
+      continue;
+    }
+
+    const sectionRange = getTomlSectionRange(lines, sectionName);
+    if (!sectionRange) {
+      continue;
+    }
+
+    const baseUrl = findTomlAssignmentInRange(
+      lines,
+      TOML_BASE_URL_PATTERN,
+      sectionRange.bodyStartIndex,
+      sectionRange.bodyEndIndex,
+      sectionName,
+    )?.value;
+    const envKey = findTomlAssignmentInRange(
+      lines,
+      TOML_ENV_KEY_PATTERN,
+      sectionRange.bodyStartIndex,
+      sectionRange.bodyEndIndex,
+      sectionName,
+    )?.value;
+
+    sections.push({
+      baseUrl,
+      envKey,
+      headerIndex: index,
+      sectionName,
+    });
+  }
+
+  return sections;
+};
+
+const getInheritedCodexBaseUrlByEnvKey = (
+  lines: string[],
+  targetSectionName: string | undefined,
+): string | undefined => {
+  if (!targetSectionName) return undefined;
+
+  const sections = getCodexModelProviderSections(lines);
+  const targetSection = sections.find(
+    (section) => section.sectionName === targetSectionName,
+  );
+  const targetEnvKey = targetSection?.envKey?.trim();
+  if (!targetSection || !targetEnvKey) return undefined;
+
+  const sameKeySections = sections.filter(
+    (section) =>
+      section.sectionName !== targetSectionName &&
+      section.envKey?.trim() === targetEnvKey &&
+      section.baseUrl?.trim(),
+  );
+  if (sameKeySections.length === 0) return undefined;
+
+  const previousSection = sameKeySections
+    .filter((section) => section.headerIndex < targetSection.headerIndex)
+    .at(-1);
+  return previousSection?.baseUrl || sameKeySections[0].baseUrl;
+};
+
 const getTopLevelModelProviderLineIndex = (lines: string[]): number => {
   const topLevelEndIndex = getTopLevelEndIndex(lines);
 
@@ -726,6 +803,14 @@ export const extractCodexBaseUrl = (
         if (match?.value) {
           return match.value;
         }
+      }
+
+      const inheritedBaseUrl = getInheritedCodexBaseUrlByEnvKey(
+        lines,
+        targetSectionName,
+      );
+      if (inheritedBaseUrl) {
+        return inheritedBaseUrl;
       }
     }
 

--- a/tests/components/ProviderList.test.tsx
+++ b/tests/components/ProviderList.test.tsx
@@ -194,8 +194,16 @@ describe("ProviderList Component", () => {
   });
 
   it("should render in order returned by useDragSort and pass through action callbacks", () => {
-    const providerA = createProvider({ id: "a", name: "A" });
-    const providerB = createProvider({ id: "b", name: "B" });
+    const providerA = createProvider({
+      id: "a",
+      name: "A",
+      settingsConfig: { env: { ANTHROPIC_API_KEY: "sk-a" } },
+    });
+    const providerB = createProvider({
+      id: "b",
+      name: "B",
+      settingsConfig: { env: { ANTHROPIC_API_KEY: "sk-b" } },
+    });
 
     const handleSwitch = vi.fn();
     const handleEdit = vi.fn();
@@ -305,5 +313,55 @@ describe("ProviderList Component", () => {
     expect(
       screen.getByText("No providers match your search."),
     ).toBeInTheDocument();
+  });
+
+  it("passes the first base URL shared by the same API key to provider cards", () => {
+    const first = createProvider({
+      id: "first",
+      name: "First",
+      settingsConfig: {
+        env: {
+          ANTHROPIC_AUTH_TOKEN: "sk-shared",
+          ANTHROPIC_BASE_URL: "https://api.tu-zi.com",
+        },
+      },
+    });
+    const second = createProvider({
+      id: "second",
+      name: "Second",
+      settingsConfig: {
+        env: {
+          ANTHROPIC_AUTH_TOKEN: "sk-shared",
+          ANTHROPIC_BASE_URL: "https://gaccode.com/claudecode",
+        },
+      },
+    });
+
+    useDragSortMock.mockReturnValue({
+      sortedProviders: [first, second],
+      sensors: [],
+      handleDragEnd: vi.fn(),
+    });
+
+    renderWithQueryClient(
+      <ProviderList
+        providers={{ first, second }}
+        currentProviderId=""
+        appId="claude"
+        onSwitch={vi.fn()}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+        onDuplicate={vi.fn()}
+        onOpenWebsite={vi.fn()}
+      />,
+    );
+
+    expect(providerCardRenderSpy).toHaveBeenCalledTimes(2);
+    expect(providerCardRenderSpy.mock.calls[0][0].resolvedQueryUrl).toBe(
+      "https://api.tu-zi.com",
+    );
+    expect(providerCardRenderSpy.mock.calls[1][0].resolvedQueryUrl).toBe(
+      "https://api.tu-zi.com",
+    );
   });
 });

--- a/tests/utils/providerConfigUtils.codex.test.ts
+++ b/tests/utils/providerConfigUtils.codex.test.ts
@@ -168,6 +168,48 @@ describe("Codex TOML utils", () => {
     expect(extractCodexBaseUrl(output)).toBe("https://api.example.com/v1");
   });
 
+  it("inherits base_url from the previous model provider with the same env_key", () => {
+    const input = [
+      'model_provider = "child"',
+      'model = "gpt-5.4"',
+      "",
+      "[model_providers.parent]",
+      'name = "parent"',
+      'base_url = "https://parent.example/v1"',
+      'env_key = "SHARED_CODEX_KEY"',
+      'wire_api = "responses"',
+      "",
+      "[model_providers.child]",
+      'name = "child"',
+      'env_key = "SHARED_CODEX_KEY"',
+      'wire_api = "responses"',
+      "",
+    ].join("\n");
+
+    expect(extractCodexBaseUrl(input)).toBe("https://parent.example/v1");
+  });
+
+  it("does not inherit base_url from another model provider with a different env_key", () => {
+    const input = [
+      'model_provider = "child"',
+      'model = "gpt-5.4"',
+      "",
+      "[model_providers.parent]",
+      'name = "parent"',
+      'base_url = "https://parent.example/v1"',
+      'env_key = "PARENT_CODEX_KEY"',
+      'wire_api = "responses"',
+      "",
+      "[model_providers.child]",
+      'name = "child"',
+      'env_key = "CHILD_CODEX_KEY"',
+      'wire_api = "responses"',
+      "",
+    ].join("\n");
+
+    expect(extractCodexBaseUrl(input)).toBeUndefined();
+  });
+
   it("recovers a single misplaced base_url from another section", () => {
     const input = [
       'model_provider = "custom"',


### PR DESCRIPTION
## 问题描述

同一个真实 API Key 代表同一个账户/余额，但列表卡片里的「查询」入口可能仍使用子项自己的 Base URL。

复现路径：
- 父级供应商：`key = sk-shared`，`baseUrl = https://api.tu-zi.com`
- 子项供应商：`key = sk-shared`，`baseUrl = https://gaccode.com/claudecode`
- 点击子项「查询」时，旧逻辑会按子项 URL 进入 gaccode 查询页，导致同 Key 查询结果不一致。

## 修复思路

- 在 `ProviderList` 中按真实 API Key 分组，记录同 Key 的首个有效 Base URL。
- 向 `ProviderCard` 传入 `resolvedQueryUrl`，查询展示和查询入口优先使用归一后的 URL。
- Codex 场景补齐同 `env_key` 的 base_url 继承：前端 TOML 解析和 Rust live 写入都支持从同 key provider 继承。

## 更新代码架构

- 新增列表层查询 URL 解析链路：`ProviderList -> ProviderCard.resolvedQueryUrl`。
- 将 Codex TOML 的同 `env_key` base_url 继承封装在解析工具与 live 写入路径中。
- 补充前端组件、Codex TOML 工具、Rust live 写入单测。

## 验证

- `pnpm vitest run tests/components/ProviderList.test.tsx tests/utils/providerConfigUtils.codex.test.ts`：29 passed
- `pnpm exec tsc --noEmit --pretty false`：通过
- `cargo test codex_base_url_inherits_from_same_env_key_provider --manifest-path src-tauri/Cargo.toml`：1 passed

> Rust 测试期间存在已有 `get_codex_version` 未使用 warning，和本次修复无关。
