### PR TITLE
fix: 修复自动更新检查与重启链路

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -170,7 +170,11 @@ jobs:
           $msi = Get-ChildItem "$bundle/msi/*.msi" | Select-Object -First 1
           if (-not $msi) { throw "MSI installer not found" }
           Copy-Item $msi.FullName "release-assets/tuzi-switch-windows-x86_64.msi"
-          if (Test-Path "$($msi.FullName).sig") {
+          $msiUpdate = Get-ChildItem "$bundle/msi/*.msi.zip" -ErrorAction SilentlyContinue | Select-Object -First 1
+          if ($msiUpdate -and (Test-Path "$($msiUpdate.FullName).sig")) {
+            Copy-Item $msiUpdate.FullName "release-assets/tuzi-switch-windows-x86_64.msi.zip"
+            Copy-Item "$($msiUpdate.FullName).sig" "release-assets/tuzi-switch-windows-x86_64.msi.zip.sig"
+          } elseif (Test-Path "$($msi.FullName).sig") {
             Copy-Item "$($msi.FullName).sig" "release-assets/tuzi-switch-windows-x86_64.msi.sig"
           }
           $setup = Get-ChildItem "$bundle/nsis/*-setup.exe" -ErrorAction SilentlyContinue | Select-Object -First 1
@@ -345,7 +349,12 @@ jobs:
               url: `${baseUrl}/tuzi-switch-macos-aarch64.app.tar.gz`,
             };
           }
-          if (fs.existsSync("dist/tuzi-switch-windows-x86_64.msi") && hasSignature("tuzi-switch-windows-x86_64.msi")) {
+          if (fs.existsSync("dist/tuzi-switch-windows-x86_64.msi.zip") && hasSignature("tuzi-switch-windows-x86_64.msi.zip")) {
+            platforms["windows-x86_64"] = {
+              signature: signature("tuzi-switch-windows-x86_64.msi.zip"),
+              url: `${baseUrl}/tuzi-switch-windows-x86_64.msi.zip`,
+            };
+          } else if (fs.existsSync("dist/tuzi-switch-windows-x86_64.msi") && hasSignature("tuzi-switch-windows-x86_64.msi")) {
             platforms["windows-x86_64"] = {
               signature: signature("tuzi-switch-windows-x86_64.msi"),
               url: `${baseUrl}/tuzi-switch-windows-x86_64.msi`,

--- a/docs/2026-06-12-自动更新链路修复-交接文档.md
+++ b/docs/2026-06-12-自动更新链路修复-交接文档.md
@@ -1,0 +1,34 @@
+# 2026-06-12 自动更新链路修复交接文档
+
+## 背景
+
+围绕 1.1.26 自动更新链路定点排查 `.github/workflows/build.yml`、`src/lib/updater.ts`、关于页更新入口与 recent fixes。当前项目使用 Tauri updater，更新清单是 `latest.json`，不是 Electron 的 `latest.yml` 或 `latest-mac.yml`。
+
+## 问题
+
+Windows 构建收集 release assets 时只收集 `.msi` 与可选 `.msi.sig`。Tauri 2 的 MSI updater 产物通常是 `.msi.zip` 和 `.msi.zip.sig`；如果 CI 只上传安装用 `.msi`，`latest.json` 生成阶段可能缺少 Windows 自动更新包，导致 Windows 用户无法走原生自动更新。
+
+客户端侧还有两个缺口：
+
+- About 页点击“检查更新”后，Tauri updater IPC 或底层请求如果长时间不返回，前端只等待插件 Promise，按钮会一直停在“检查中”。
+- macOS 原生安装完成后调用 `relaunch()` 会触发 Tauri 的重启退出码，但项目统一拦截 `ExitRequested` 并 `std::process::exit(0)`，可能截断 Tauri 原生 `restart_on_exit` 流程，表现为更新后卡住、需强制退出或未自动重启。
+
+## 修复
+
+- Windows release assets 收集阶段新增 `.msi.zip` 与 `.msi.zip.sig` 收集。
+- `latest.json` 生成阶段优先使用 `tuzi-switch-windows-x86_64.msi.zip`，缺失时才回退到旧的 `tuzi-switch-windows-x86_64.msi`。
+- 保留 `.msi` 安装包上传逻辑，不影响用户手动下载安装。
+- 客户端更新检查新增前端总超时兜底，避免 Tauri updater IPC 或底层请求不返回时 About 页一直停在“检查中”。
+- Tauri updater 返回 `null` 时继续用 GitHub latest release 做版本兜底，避免原生清单/平台判断异常时漏掉已发布的新版本提示。
+- 原生安装完成后先释放按钮 loading，并提示“更新已安装，正在重启”，避免重启接管慢时界面看起来卡死。
+- 后端识别 `tauri::RESTART_EXIT_CODE` 并放行，不再拦截 Tauri 原生重启流程。
+
+## 未改动
+
+- 未改动任何本地 API 配置、供应商配置或用户配置读写逻辑。
+
+## 风险与后续
+
+- 如果发布监控仍检查 `latest.yml/latest-mac.yml`，需要改为检查 Tauri 的 `latest.json`。
+- 发布后建议确认 Release Assets 中同时存在 Windows `.msi` 与 `.msi.zip/.sig`，并确认 `latest.json` 的 `windows-x86_64.url` 指向 `.msi.zip`。
+- 如果后续调整全局退出清理逻辑，必须保留 `tauri::RESTART_EXIT_CODE` 放行规则，否则会再次破坏插件 `relaunch()`。

--- a/qa/2026-06-12-自动更新链路修复-人工测试文档.md
+++ b/qa/2026-06-12-自动更新链路修复-人工测试文档.md
@@ -1,0 +1,35 @@
+# 2026-06-12 自动更新链路修复人工测试文档
+
+## 测试范围
+
+- GitHub Actions release workflow 中 Windows updater 产物收集。
+- `latest.json` 生成逻辑对 Windows `.msi.zip` 的优先选择。
+- 关于页“检查更新”入口的静态链路确认。
+
+## 已执行验证
+
+1. 检查版本一致性：`package.json`、`src-tauri/tauri.conf.json`、`src-tauri/Cargo.toml` 均为 `1.1.26`。
+2. 检查 Tauri updater manifest schema：Tauri updater 读取 `latest.json` 的 `version`、`pub_date`、`platforms.*.url` 与 `platforms.*.signature`。
+3. 检查关于页入口：普通安装版使用 `checkUpdate()`，存在更新时调用 `updateHandle.downloadAndInstall()`；原生检查失败时由 `src/lib/updater.ts` 降级到 GitHub latest release。
+4. 检查便携版入口：便携模式只调用后端更新检查，不会改写供应商或 API 配置。
+5. 单元测试覆盖：Tauri updater 检查卡住时会超时转 GitHub latest release；Tauri updater 返回无更新时也会用 GitHub latest release 兜底发现新版本。
+6. Rust 检查覆盖：`cargo check` 确认 `tauri::RESTART_EXIT_CODE` 放行逻辑可编译。
+
+## 发布后人工验证
+
+1. 打开 GitHub Release，确认 Windows assets 同时包含：
+   - `tuzi-switch-windows-x86_64.msi`
+   - `tuzi-switch-windows-x86_64.msi.zip`
+   - `tuzi-switch-windows-x86_64.msi.zip.sig`
+2. 打开 `latest.json`，确认 `platforms.windows-x86_64.url` 指向 `.msi.zip`。
+3. 在旧版本 Windows 安装版点击关于页“检查更新”，确认可以发现新版本并进入下载/安装流程。
+4. 在 macOS 或 Linux 点击关于页“检查更新”，确认仍可发现新版本或提示已是最新。
+5. 验证过程中不进入供应商编辑页，不保存设置，不修改 API Key。
+6. 点击“更新到 vX.Y.Z”后，确认安装完成会出现重启提示；如系统未自动重启，手动退出再打开后版本号应已更新。
+7. macOS 安装版更新时，确认安装完成后应用会自动退出并重新打开；不应长期停留在“更新中”。
+
+## 回归关注
+
+- 如果 `TAURI_SIGNING_PRIVATE_KEY` 未配置，CI 仍会跳过原生 updater artifacts，此时客户端应依赖 GitHub release fallback 提示手动更新。
+- 如果 `.msi.zip.sig` 缺失，`latest.json` 会回退旧 `.msi.sig` 路径；若两者都缺失，Windows 原生自动更新项不会生成。
+- 如果重启流程再次卡住，优先检查 `ExitRequested` 是否重新拦截了 `tauri::RESTART_EXIT_CODE`。

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1427,6 +1427,11 @@ pub fn run() {
     app.run(|app_handle, event| {
         // 处理退出请求（所有平台）
         if let RunEvent::ExitRequested { api, code, .. } = &event {
+            if *code == Some(tauri::RESTART_EXIT_CODE) {
+                log::info!("收到应用重启请求，交由 Tauri 原生重启流程处理");
+                return;
+            }
+
             // code 为 None 表示运行时自动触发（如隐藏窗口的 WebView 被回收导致无存活窗口），
             // 此时应仅阻止退出、保持托盘后台运行；
             // code 为 Some(_) 表示用户主动调用 app.exit() 退出（如托盘菜单"退出"），

--- a/src/components/settings/AboutSection.tsx
+++ b/src/components/settings/AboutSection.tsx
@@ -291,6 +291,10 @@ export function AboutSection({ isPortable }: AboutSectionProps) {
             closeButton: true,
           });
         } else {
+          setIsDownloading(false);
+          toast.success(t("settings.updateInstalledRestarting"), {
+            closeButton: true,
+          });
           await relaunchApp();
         }
       } catch (error) {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -641,6 +641,7 @@
     "updateBadge": "Update available",
     "updateFailed": "Update installation failed, attempted to open download page.",
     "updatePageOpened": "Opened the download page. Please download and install the new version manually.",
+    "updateInstalledRestarting": "Update installed. Restarting the app. If it does not restart automatically, please quit and reopen it.",
     "checkUpdateFailed": "Failed to check for updates, please try again later.",
     "openReleaseNotesFailed": "Failed to open release notes",
     "releaseNotes": "Release Notes",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -641,6 +641,7 @@
     "updateBadge": "更新あり",
     "updateFailed": "更新のインストールに失敗しました。ダウンロードページを開こうとしました。",
     "updatePageOpened": "ダウンロードページを開きました。新しいバージョンを手動でインストールしてください。",
+    "updateInstalledRestarting": "更新をインストールしました。アプリを再起動しています。自動で再起動しない場合は、手動で終了して開き直してください。",
     "checkUpdateFailed": "更新の確認に失敗しました。時間をおいて再試行してください。",
     "openReleaseNotesFailed": "リリースノートの表示に失敗しました",
     "releaseNotes": "リリースノート",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -641,6 +641,7 @@
     "updateBadge": "有更新可用",
     "updateFailed": "更新安装失败，已尝试打开下载页面。",
     "updatePageOpened": "已打开新版本下载页面，请下载并手动安装。",
+    "updateInstalledRestarting": "更新已安装，正在重启应用。如未自动重启，请手动退出后重新打开。",
     "checkUpdateFailed": "检查更新失败，请稍后重试。",
     "openReleaseNotesFailed": "打开更新日志失败",
     "releaseNotes": "更新日志",

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -60,6 +60,23 @@ const RELEASES_URL = "https://github.com/tuziapi/tuzi-switch/releases";
 const GITHUB_LATEST_RELEASE_API =
   "https://api.github.com/repos/tuziapi/tuzi-switch/releases/latest";
 
+function withTimeout<T>(
+  promise: Promise<T>,
+  timeout: number,
+  message: string,
+): Promise<T> {
+  let timer: number | undefined;
+  const timeoutPromise = new Promise<T>((_, reject) => {
+    timer = window.setTimeout(() => reject(new Error(message)), timeout);
+  });
+
+  return Promise.race([promise, timeoutPromise]).finally(() => {
+    if (timer !== undefined) {
+      window.clearTimeout(timer);
+    }
+  });
+}
+
 function mapUpdateHandle(raw: Update): UpdateHandle {
   return {
     version: raw.version ?? "",
@@ -186,19 +203,27 @@ export async function checkForUpdate(
   | { status: "up-to-date" }
   | { status: "available"; info: UpdateInfo; update: UpdateHandle }
 > {
-  const { check } = await import("@tauri-apps/plugin-updater");
-  const currentVersion = await getCurrentVersion();
-
   const timeout = opts.timeout ?? 30000;
+  const currentVersion = await withTimeout(
+    getCurrentVersion(),
+    timeout,
+    "Get current app version timed out",
+  ).catch(() => "");
+
   let update: Update | null;
   try {
-    update = await check({ timeout } as any);
+    const { check } = await import("@tauri-apps/plugin-updater");
+    update = await withTimeout(
+      check({ timeout } as any),
+      timeout,
+      "Tauri updater check timed out",
+    );
   } catch (error) {
     console.warn("Tauri updater check failed, falling back to GitHub release", error);
     return await checkGitHubReleaseFallback(currentVersion, timeout);
   }
   if (!update) {
-    return { status: "up-to-date" };
+    return await checkGitHubReleaseFallback(currentVersion, timeout);
   }
 
   const mapped = mapUpdateHandle(update);

--- a/tests/lib/updater.test.ts
+++ b/tests/lib/updater.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+
+const checkMock = vi.fn();
+const getVersionMock = vi.fn();
+const invokeMock = vi.fn();
+
+vi.mock("@tauri-apps/plugin-updater", () => ({
+  check: checkMock,
+}));
+
+vi.mock("@tauri-apps/api/app", () => ({
+  getVersion: getVersionMock,
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: invokeMock,
+}));
+
+describe("checkForUpdate", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    checkMock.mockReset();
+    getVersionMock.mockReset();
+    invokeMock.mockReset();
+    getVersionMock.mockResolvedValue("1.1.26");
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("falls back to GitHub release when Tauri updater check hangs", async () => {
+    checkMock.mockReturnValue(new Promise(() => {}));
+    mockLatestRelease();
+
+    const { checkForUpdate } = await import("@/lib/updater");
+    const resultPromise = checkForUpdate({ timeout: 100 });
+
+    await vi.advanceTimersByTimeAsync(100);
+    const result = await resultPromise;
+
+    expect(result.status).toBe("available");
+    if (result.status === "available") {
+      expect(result.info.availableVersion).toBe("1.1.27");
+      expect(result.update.manual).toBe(true);
+    }
+  });
+
+  it("falls back to GitHub release when Tauri updater reports no update", async () => {
+    checkMock.mockResolvedValue(null);
+    mockLatestRelease();
+
+    const { checkForUpdate } = await import("@/lib/updater");
+    const result = await checkForUpdate({ timeout: 100 });
+
+    expect(result.status).toBe("available");
+    if (result.status === "available") {
+      expect(result.info.currentVersion).toBe("1.1.26");
+      expect(result.info.availableVersion).toBe("1.1.27");
+    }
+  });
+});
+
+function mockLatestRelease() {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        tag_name: "v1.1.27",
+        name: "兔子switch v1.1.27",
+        body: "release notes",
+        published_at: "2026-06-11T11:16:49.254Z",
+      }),
+    }),
+  );
+}


### PR DESCRIPTION
## 问题
- 关于页检查更新可能一直停在“检查中”，导致用户看不到新版本提示。
- Tauri updater 返回空结果时不会继续用 GitHub latest release 兜底，可能漏掉已发布版本。
- macOS 安装后 relaunch 会被项目自定义 ExitRequested 拦截截断，可能表现为更新后卡住或需要强退。
- Windows 发布流程可能只上传 .msi，缺少 Tauri MSI updater 常用的 .msi.zip/.sig 自动更新包。

## 修复
- 为客户端更新检查增加前端总超时，并在超时/失败/空结果时走 GitHub latest release fallback。
- About 页安装完成后释放 loading 并提示正在重启。
- 后端放行 tauri::RESTART_EXIT_CODE，让 Tauri 原生重启流程继续执行。
- CI 收集 Windows .msi.zip/.sig，并在 latest.json 中优先使用 .msi.zip。
- 补充 updater 单元测试、交接文档和人工测试文档。

## 验证
- pnpm exec vitest run tests/lib/updater.test.ts
- pnpm typecheck
- cargo check
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/build.yml")'\n- git diff --check\n\n## 备注\n- cargo check 仅有既有 get_codex_version dead_code warning。\n- 未改动本地 API 配置、供应商配置或用户配置读写逻辑。