### PR TITLE
fix: 适配模型厂商最新配置方式

### DIFF
--- a/docs/2026-06-13-模型厂商最新配置方式适配-交接文档.md
+++ b/docs/2026-06-13-模型厂商最新配置方式适配-交接文档.md
@@ -1,0 +1,75 @@
+# 模型厂商最新配置方式适配交接文档
+
+## 问题描述
+
+- Codex 新版 `config.toml` 已把自定义厂商配置集中到 `[model_providers.<id>]`，并支持 headers、query params、重试、超时、鉴权模式等扩展字段。
+- 兔子switch 原先保存 Codex route 时只重建固定字段，会丢失或覆盖厂商扩展字段。
+- 新增/更新非当前 Codex 供应商时，`ensure_codex_provider_registered()` 仍走旧保存函数，登记到主 `~/.codex/config.toml` 时同样可能丢扩展字段。
+- 带 `[model_providers.<id>.headers]` 这类嵌套子表的供应商再次保存时，旧 section 移除逻辑只删主表，不删子表，可能生成重复 table 并导致 TOML 解析失败。
+- Gemini `.env` 原先直接写入值，遇到空格、引号、换行等特殊字符时，重启 Gemini CLI 后可能读到截断或错误配置。
+- Hermes 预设已扩展到更多厂商，但测试仍断言只有早期 5 个预设，CI 会误报失败。
+
+## 修复思路
+
+- Codex route 写入新增 `save_route_to_config_with_provider_config()`：
+  - 从供应商自身 config 中读取同名 `[model_providers.<route>]`。
+  - 只覆盖必须跟当前表单一致的 `name`、`base_url`、`env_key`。
+  - `wire_api` 和 `requires_openai_auth` 仅在缺失时补默认值，已有值保持厂商配置。
+  - 保留 `request_max_retries`、`stream_idle_timeout_ms`、headers、query params 等未知/扩展字段。
+- Codex 新增/更新但不切换当前供应商的登记路径也改用同一保存函数，避免非当前供应商落盘时丢字段。
+- `remove_section()` 支持移除目标 section 的嵌套子表，避免 `[model_providers.xxx.headers]` 残留造成重复 table。
+- Gemini `.env` 增加安全序列化：
+  - 简单值保持原样，减少无意义 diff。
+  - 特殊值用双引号包裹，并转义 `\`、`"`、换行、回车、tab。
+  - 解析端支持相同转义，保证 roundtrip。
+- Hermes 预设测试改成验证 tuzi 管理预设仍位于前 5 个，而不是阻止新增其他厂商。
+
+## 更新代码架构
+
+- `src-tauri/src/codex_config.rs`
+  - 新增带 provider config 的 route 保存函数。
+  - 新增 provider section 构造与嵌套 section 提取逻辑。
+  - `remove_section()` 支持目标 section 的子表清理。
+  - 新增 Codex 扩展字段保留和缺失 provider table 创建测试。
+- `src-tauri/src/services/provider/live.rs`
+  - Codex live 写入和非当前供应商登记路径都传入原始 provider config。
+- `src-tauri/src/commands/config.rs`
+  - Codex 保存入口传入归一化后的 provider config，确保前端保存和 live 落盘使用同一份字段。
+- `src-tauri/src/gemini_config.rs`
+  - `.env` 读写增加特殊字符转义和反转义。
+- `src-tauri/tests/provider_service.rs`
+  - 新增 Codex 非当前供应商登记时保留扩展字段的集成测试。
+- `tests/config/hermesProviderPresets.test.ts`
+  - 调整 Hermes 预设顺序断言，允许扩展更多厂商。
+
+## 厂商配置适配矩阵
+
+| 应用 | 当前适配方式 | 本次重点 |
+| --- | --- | --- |
+| Codex | `~/.codex/config.toml`、profile config、managed env | 保留 `[model_providers.<id>]` 扩展字段和嵌套子表，尊重厂商 `wire_api`/`requires_openai_auth` |
+| Claude Code | `~/.claude/settings.json` 的 `env` | 延续新版 settings 路径；保留非内部字段 |
+| Gemini CLI | `~/.gemini/.env` + `settings.json` | `.env` 安全转义，避免特殊字符写坏 |
+| OpenCode/OpenClaw | 累加式 provider 配置 | 本次未改行为，文档中纳入回归检查 |
+| Hermes | `custom_providers` / v12+ `providers:` dict | 保持扩展预设可测试；只读来源仍交由 Hermes Web UI |
+
+## 官方资料核对
+
+- Codex 配置参考：`https://developers.openai.com/codex/config-reference/`
+- Claude Code settings：`https://code.claude.com/docs/en/settings`
+- Gemini CLI configuration：`https://github.com/google-gemini/gemini-cli/blob/main/docs/cli/configuration.md`
+
+## 风险与注意事项
+
+- 本次保留同 route 下的扩展字段，不会把其他 route 的 headers/query params 自动搬到新 route，避免串供应商配置。
+- `base_url`、`env_key` 仍以兔子switch 表单/归一化结果为准，这是用户保存动作的明确输入。
+- 如果后续 Codex 官方新增必须由顶层控制的 provider 字段，需要继续扩展保留测试。
+- Gemini `.env` 只处理双引号转义，不引入复杂 shell 展开，避免把配置文件变成脚本解释器。
+- Hermes 本次只修测试断言，不改变 Hermes live 写入逻辑。
+
+## 验证记录
+
+- `cargo test --test provider_service codex -- --nocapture --test-threads=1`
+- `cargo test codex_config::tests::save_route_to_config -- --nocapture --test-threads=1`
+- `cargo test gemini_config::tests -- --nocapture --test-threads=1`
+- `pnpm -s exec vitest run tests/config/hermesProviderPresets.test.ts`
+- `pnpm -s exec tsc --noEmit`

--- a/qa/2026-06-13-模型厂商最新配置方式适配-人工测试文档.md
+++ b/qa/2026-06-13-模型厂商最新配置方式适配-人工测试文档.md
@@ -1,0 +1,116 @@
+# 模型厂商最新配置方式适配人工测试文档
+
+## 测试环境
+
+- 兔子switch：1.1.29 待发布构建
+- Codex CLI：0.134.0 或更新
+- Claude Code：使用 `~/.claude/settings.json`
+- Gemini CLI：使用 `~/.gemini/.env`
+- Hermes：包含扩展预设的当前前端配置
+
+## 测试用例
+
+### 1. Codex 新增非当前供应商保留扩展字段
+
+1. 准备已有 `~/.codex/config.toml`，当前 provider 为 A。
+2. 在兔子switch 新增 Codex 供应商 B，B 的 TOML 含：
+   - `wire_api = "chat"` 或其他非默认值。
+   - `requires_openai_auth = false`。
+   - `request_max_retries`、`stream_idle_timeout_ms`。
+   - `[model_providers.B.headers]`。
+3. 保存但不点击启用。
+4. 检查 `~/.codex/config.toml`。
+
+预期：
+
+- 顶层 `model_provider` 仍为 A。
+- `[model_providers.B]` 已登记。
+- B 的扩展字段和嵌套 headers 保留。
+- `wire_api`、`requires_openai_auth` 不被强行改回默认值。
+
+### 2. Codex 重复保存带 headers 的供应商
+
+1. 对同一个 Codex 供应商连续保存两次。
+2. 第二次保存前后都保留 `[model_providers.<id>.headers]`。
+3. 用 Codex 或 TOML 解析器读取 `~/.codex/config.toml`。
+
+预期：
+
+- 不出现重复 `[model_providers.<id>.headers]`。
+- TOML 可正常解析。
+- headers 不丢失。
+
+### 3. Codex 当前供应商切换保留扩展字段
+
+1. 准备带扩展字段的 Codex 供应商。
+2. 点击启用。
+3. 检查 `~/.codex/config.toml` 和 `~/.codex/<供应商名>.config.toml`。
+
+预期：
+
+- live 配置切到目标 provider。
+- profile 文件存在。
+- 扩展字段和嵌套子表保留。
+
+### 4. Gemini .env 特殊字符
+
+1. 在 Gemini 供应商配置中写入包含空格、引号或换行的 API Key/base URL 测试值。
+2. 保存配置。
+3. 检查 `~/.gemini/.env`。
+4. 重启 Gemini CLI 或重新导入配置。
+
+预期：
+
+- 特殊值被双引号包裹并转义。
+- 重新读取后值与保存前一致。
+- 普通 URL/API Key 不产生额外引号。
+
+### 5. Claude Code settings 路径
+
+1. 保存 Claude 供应商配置。
+2. 检查 `~/.claude/settings.json`。
+3. 重启 Claude Code。
+
+预期：
+
+- 配置写入 `settings.json`。
+- 用户自定义 env 字段保留。
+- 内部字段如 `apiFormat` 不写入 Claude live 配置。
+
+### 6. Hermes 预设列表
+
+1. 打开 Hermes 新增供应商。
+2. 检查预设列表前 5 个。
+3. 搜索或浏览新增厂商预设。
+
+预期：
+
+- 前 5 个仍是 tuzi 管理预设：`codex-tuzi`、`codex-coding`、`codex-gaccode`、`claude-tuzi`、`claude-gaccode`。
+- 后续新增厂商预设可见。
+- `codex-gaccode` 为 `codex_responses`，`claude-gaccode` 为 `anthropic_messages`。
+
+### 7. OpenCode/OpenClaw/Hermes 回归
+
+1. 从 live 配置导入已有供应商。
+2. 编辑并保存供应商。
+3. 再次读取 live 配置。
+
+预期：
+
+- 未在表单暴露的 extra 字段不应被无故删除。
+- Hermes v12+ `providers:` dict 来源仍按只读处理。
+- 删除卡片仍只删除兔子switch DB，不删除真实客户端配置。
+
+## 自动化验证
+
+- `cargo test --test provider_service codex -- --nocapture --test-threads=1`
+- `cargo test codex_config::tests::save_route_to_config -- --nocapture --test-threads=1`
+- `cargo test gemini_config::tests -- --nocapture --test-threads=1`
+- `pnpm -s exec vitest run tests/config/hermesProviderPresets.test.ts`
+- `pnpm -s exec tsc --noEmit`
+
+## 回滚建议
+
+- 若 Codex 保存后出现 TOML 解析失败，优先检查重复 `[model_providers.<id>.*]` 子表。
+- 若某厂商要求固定 `wire_api = "responses"`，应在该预设或表单层显式生成，而不是在通用保存层强制覆盖所有厂商。
+- 发布失败可回滚本次 PR，并保留 1.1.27/1.1.28 的自动更新修复策略作为基线。

--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -342,14 +342,32 @@ pub fn save_route_to_config(
     model: &str,
     model_reasoning_effort: &str,
 ) -> Result<String, AppError> {
+    save_route_to_config_with_provider_config(
+        existing_config,
+        route_id,
+        base_url,
+        env_key,
+        model,
+        model_reasoning_effort,
+        None,
+    )
+}
+
+/// Save a route while preserving any future/optional fields already present
+/// under the provider's own `[model_providers.<route>]` table.
+pub fn save_route_to_config_with_provider_config(
+    existing_config: &str,
+    route_id: &str,
+    base_url: &str,
+    env_key: &str,
+    model: &str,
+    model_reasoning_effort: &str,
+    provider_config: Option<&str>,
+) -> Result<String, AppError> {
     let new_format = is_new_profile_format();
 
-    let mut provider_section = format!(
-        "[model_providers.{route_id}]\nname = \"{route_id}\"\nbase_url = \"{base_url}\"\nwire_api = \"responses\"\nrequires_openai_auth = true\n"
-    );
-    if !env_key.trim().is_empty() {
-        provider_section.push_str(&format!("env_key = \"{env_key}\"\n"));
-    }
+    let provider_section =
+        build_model_provider_section(route_id, base_url, env_key, provider_config)?;
 
     let mut lines: Vec<String> = existing_config.lines().map(|l| l.to_string()).collect();
 
@@ -414,6 +432,101 @@ pub fn save_route_to_config(
     Ok(result)
 }
 
+fn build_model_provider_section(
+    route_id: &str,
+    base_url: &str,
+    env_key: &str,
+    provider_config: Option<&str>,
+) -> Result<String, AppError> {
+    let mut doc = provider_config
+        .filter(|config| !config.trim().is_empty())
+        .map(|config| {
+            config
+                .parse::<DocumentMut>()
+                .map_err(|e| AppError::Message(format!("Invalid Codex config.toml: {e}")))
+        })
+        .transpose()?
+        .unwrap_or_default();
+
+    if !doc
+        .get("model_providers")
+        .and_then(|item| item.as_table())
+        .is_some()
+    {
+        doc["model_providers"] = toml_edit::Item::Table(toml_edit::Table::new());
+    }
+
+    if let Some(providers) = doc
+        .get_mut("model_providers")
+        .and_then(|item| item.as_table_mut())
+    {
+        if !providers.contains_key(route_id) {
+            providers.insert(route_id, toml_edit::Item::Table(toml_edit::Table::new()));
+        }
+    }
+
+    let Some(table) = doc
+        .get_mut("model_providers")
+        .and_then(|item| item.as_table_mut())
+        .and_then(|providers| providers.get_mut(route_id))
+        .and_then(|item| item.as_table_mut())
+    else {
+        return Err(AppError::Message(format!(
+            "Failed to prepare Codex provider section for '{route_id}'"
+        )));
+    };
+
+    table["name"] = toml_edit::value(route_id);
+    table["base_url"] = toml_edit::value(base_url);
+    if !table.contains_key("wire_api") {
+        table["wire_api"] = toml_edit::value("responses");
+    }
+    if !table.contains_key("requires_openai_auth") {
+        table["requires_openai_auth"] = toml_edit::value(true);
+    }
+    if env_key.trim().is_empty() {
+        table.remove("env_key");
+    } else {
+        table["env_key"] = toml_edit::value(env_key);
+    }
+
+    extract_model_provider_section_text(&doc.to_string(), route_id).ok_or_else(|| {
+        AppError::Message(format!(
+            "Failed to render Codex provider section for '{route_id}'"
+        ))
+    })
+}
+
+fn extract_model_provider_section_text(config_text: &str, route_id: &str) -> Option<String> {
+    let header = format!("[model_providers.{route_id}]");
+    let nested_prefix = format!("[model_providers.{route_id}.");
+    let mut result = Vec::new();
+    let mut in_section = false;
+
+    for line in config_text.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with('[') {
+            if trimmed == header || trimmed.starts_with(&nested_prefix) {
+                in_section = true;
+            } else if in_section {
+                break;
+            }
+        }
+
+        if in_section {
+            result.push(line);
+        }
+    }
+
+    if result.is_empty() {
+        None
+    } else {
+        let mut text = result.join("\n");
+        text.push('\n');
+        Some(text)
+    }
+}
+
 /// Remove a route's [profiles.xxx] and [model_providers.xxx] sections from config.toml.
 #[allow(dead_code)]
 pub fn remove_route_from_config(config_text: &str, route_id: &str) -> String {
@@ -436,12 +549,18 @@ pub fn remove_route_from_config(config_text: &str, route_id: &str) -> String {
 fn remove_section(lines: &[String], header: &str) -> Vec<String> {
     let mut result = Vec::new();
     let mut skipping = false;
+    let nested_header_prefix = header.strip_suffix(']').map(|prefix| format!("{prefix}."));
     for line in lines {
-        if line.trim() == header {
+        let trimmed = line.trim();
+        let is_target_header = trimmed == header
+            || nested_header_prefix
+                .as_deref()
+                .is_some_and(|prefix| trimmed.starts_with(prefix));
+        if is_target_header {
             skipping = true;
             continue;
         }
-        if skipping && line.trim().starts_with('[') {
+        if skipping && trimmed.starts_with('[') {
             skipping = false;
         }
         if !skipping {
@@ -2510,5 +2629,104 @@ base_url = "https://production.api/v1"
             .and_then(|v| v.get("base_url"))
             .and_then(|v| v.as_str());
         assert_eq!(base_url, Some("https://production.api/v1"));
+    }
+
+    #[test]
+    fn save_route_to_config_preserves_provider_extension_fields() {
+        let provider_config = r#"model_provider = "vendor"
+model = "gpt-5.5"
+
+[model_providers.vendor]
+name = "Vendor"
+base_url = "https://old.example/v1"
+env_key = "OLD_KEY"
+wire_api = "chat"
+requires_openai_auth = false
+request_max_retries = 4
+stream_idle_timeout_ms = 300000
+
+[model_providers.vendor.headers]
+X-Custom-Trace = "keep-me"
+"#;
+
+        let result = save_route_to_config_with_provider_config(
+            "",
+            "vendor",
+            "https://new.example/v1",
+            "NEW_KEY",
+            "gpt-5.5",
+            "high",
+            Some(provider_config),
+        )
+        .expect("save route");
+        let parsed: toml::Value = toml::from_str(&result).expect("parse result");
+        let provider = parsed
+            .get("model_providers")
+            .and_then(|v| v.get("vendor"))
+            .expect("provider table");
+
+        assert_eq!(
+            provider.get("base_url").and_then(|v| v.as_str()),
+            Some("https://new.example/v1")
+        );
+        assert_eq!(
+            provider.get("env_key").and_then(|v| v.as_str()),
+            Some("NEW_KEY")
+        );
+        assert_eq!(
+            provider
+                .get("request_max_retries")
+                .and_then(|v| v.as_integer()),
+            Some(4)
+        );
+        assert_eq!(
+            provider
+                .get("stream_idle_timeout_ms")
+                .and_then(|v| v.as_integer()),
+            Some(300000)
+        );
+        assert_eq!(
+            provider
+                .get("headers")
+                .and_then(|v| v.get("X-Custom-Trace"))
+                .and_then(|v| v.as_str()),
+            Some("keep-me")
+        );
+    }
+
+    #[test]
+    fn save_route_to_config_creates_missing_provider_table_from_template() {
+        let provider_config = r#"model_provider = "template"
+model = "gpt-5.5"
+
+[model_providers.template]
+request_max_retries = 2
+stream_idle_timeout_ms = 180000
+"#;
+
+        let result = save_route_to_config_with_provider_config(
+            "",
+            "new_vendor",
+            "https://new.example/v1",
+            "NEW_VENDOR_CODEX_API_KEY",
+            "gpt-5.5",
+            "high",
+            Some(provider_config),
+        )
+        .expect("save route");
+        let parsed: toml::Value = toml::from_str(&result).expect("parse result");
+        let provider = parsed
+            .get("model_providers")
+            .and_then(|v| v.get("new_vendor"))
+            .expect("new provider table");
+
+        assert_eq!(
+            provider.get("base_url").and_then(|v| v.as_str()),
+            Some("https://new.example/v1")
+        );
+        assert_eq!(
+            provider.get("env_key").and_then(|v| v.as_str()),
+            Some("NEW_VENDOR_CODEX_API_KEY")
+        );
     }
 }

--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -532,13 +532,14 @@ fn save_codex_route_inner(
 
     // Write route section to config.toml
     let existing = codex_config::read_codex_config_text().map_err(|e| e.to_string())?;
-    let updated = codex_config::save_route_to_config(
+    let updated = codex_config::save_route_to_config_with_provider_config(
         &existing,
         &normalized_route_id,
         &normalized_base_url,
         &normalized_env_key,
         &model,
         &modelReasoningEffort,
+        Some(normalized_config),
     )
     .map_err(|e| e.to_string())?;
 

--- a/src-tauri/src/gemini_config.rs
+++ b/src-tauri/src/gemini_config.rs
@@ -37,7 +37,7 @@ pub fn parse_env_file(content: &str) -> HashMap<String, String> {
         // 解析 KEY=VALUE
         if let Some((key, value)) = line.split_once('=') {
             let key = key.trim().to_string();
-            let value = value.trim().to_string();
+            let value = parse_env_value(value.trim());
 
             // 验证 key 是否有效（不为空，只包含字母、数字和下划线）
             if !key.is_empty() && key.chars().all(|c| c.is_alphanumeric() || c == '_') {
@@ -132,11 +132,65 @@ pub fn serialize_env_file(map: &HashMap<String, String>) -> String {
 
     for key in keys {
         if let Some(value) = map.get(key) {
-            lines.push(format!("{key}={value}"));
+            lines.push(format!("{key}={}", serialize_env_value(value)));
         }
     }
 
     lines.join("\n")
+}
+
+fn parse_env_value(value: &str) -> String {
+    let value = value.trim();
+    if value.len() < 2 || !value.starts_with('"') || !value.ends_with('"') {
+        return value.to_string();
+    }
+
+    let inner = &value[1..value.len() - 1];
+    let mut result = String::new();
+    let mut chars = inner.chars();
+    while let Some(ch) = chars.next() {
+        if ch != '\\' {
+            result.push(ch);
+            continue;
+        }
+
+        match chars.next() {
+            Some('n') => result.push('\n'),
+            Some('r') => result.push('\r'),
+            Some('t') => result.push('\t'),
+            Some('"') => result.push('"'),
+            Some('\\') => result.push('\\'),
+            Some(other) => {
+                result.push('\\');
+                result.push(other);
+            }
+            None => result.push('\\'),
+        }
+    }
+    result
+}
+
+fn serialize_env_value(value: &str) -> String {
+    if !value.is_empty()
+        && value
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.' | '/' | ':' | '@'))
+    {
+        return value.to_string();
+    }
+
+    let mut escaped = String::new();
+    for ch in value.chars() {
+        match ch {
+            '\\' => escaped.push_str("\\\\"),
+            '"' => escaped.push_str("\\\""),
+            '\n' => escaped.push_str("\\n"),
+            '\r' => escaped.push_str("\\r"),
+            '\t' => escaped.push_str("\\t"),
+            other => escaped.push(other),
+        }
+    }
+    format!("\"{escaped}\"")
 }
 
 /// 读取 Gemini .env 文件
@@ -412,6 +466,32 @@ GEMINI_MODEL=gemini-3-pro-preview
 
         assert!(content.contains("GEMINI_API_KEY=sk-test"));
         assert!(content.contains("GEMINI_MODEL=gemini-3-pro-preview"));
+    }
+
+    #[test]
+    fn test_serialize_env_file_quotes_special_values_and_round_trips() {
+        let mut map = HashMap::new();
+        map.insert(
+            "GEMINI_API_KEY".to_string(),
+            "sk test \"quoted\"\nnext".to_string(),
+        );
+        map.insert(
+            "GOOGLE_GEMINI_BASE_URL".to_string(),
+            "https://example.com/gemini api".to_string(),
+        );
+
+        let content = serialize_env_file(&map);
+        assert!(
+            content.contains("GEMINI_API_KEY=\"sk test \\\"quoted\\\"\\nnext\""),
+            "API key with spaces, quotes and newline should be escaped"
+        );
+        assert!(
+            content.contains("GOOGLE_GEMINI_BASE_URL=\"https://example.com/gemini api\""),
+            "base URL with spaces should be quoted"
+        );
+
+        let parsed = parse_env_file(&content);
+        assert_eq!(parsed, map);
     }
 
     #[test]

--- a/src-tauri/src/services/provider/live.rs
+++ b/src-tauri/src/services/provider/live.rs
@@ -276,8 +276,14 @@ pub(crate) fn ensure_codex_provider_registered(provider: &Provider) -> Result<()
         .unwrap_or_else(|| "high".to_string());
     let base_url = codex_active_provider_string_field(config_str, "base_url").unwrap_or_default();
 
-    let updated = crate::codex_config::save_route_to_config(
-        &existing, &route_id, &base_url, &env_key, &model, &effort,
+    let updated = crate::codex_config::save_route_to_config_with_provider_config(
+        &existing,
+        &route_id,
+        &base_url,
+        &env_key,
+        &model,
+        &effort,
+        Some(config_str),
     )?;
     crate::codex_config::write_codex_live_config_atomic(Some(&updated))?;
     crate::codex_config::write_codex_profile_config(&provider.name, config_str)?;
@@ -996,8 +1002,9 @@ pub(crate) fn write_live_snapshot(app_type: &AppType, provider: &Provider) -> Re
             let config_str = obj.get("config").and_then(|v| v.as_str()).unwrap_or("");
 
             use crate::codex_config::{
-                read_codex_config_text, save_route_to_config, switch_codex_profile,
-                write_codex_profile_config, write_codex_provider_live_with_catalog,
+                read_codex_config_text, save_route_to_config_with_provider_config,
+                switch_codex_profile, write_codex_profile_config,
+                write_codex_provider_live_with_catalog,
             };
 
             if config_str.trim().is_empty() {
@@ -1029,8 +1036,15 @@ pub(crate) fn write_live_snapshot(app_type: &AppType, provider: &Provider) -> Re
             let base_url =
                 codex_active_provider_string_field(config_str, "base_url").unwrap_or_default();
 
-            let config_with_route =
-                save_route_to_config(&existing, &route_id, &base_url, &env_key, &model, &effort)?;
+            let config_with_route = save_route_to_config_with_provider_config(
+                &existing,
+                &route_id,
+                &base_url,
+                &env_key,
+                &model,
+                &effort,
+                Some(config_str),
+            )?;
 
             // Switch top-level fields (model_provider + model + effort)
             let mut final_config =

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -1274,10 +1274,7 @@ impl ProviderService {
         }
 
         if matches!(app_type, AppType::OpenCode) {
-            for variant in [
-                &crate::services::omo::STANDARD,
-                &crate::services::omo::SLIM,
-            ] {
+            for variant in [&crate::services::omo::STANDARD, &crate::services::omo::SLIM] {
                 if state
                     .db
                     .is_omo_provider_current(app_type.as_str(), id, variant.category)?

--- a/src-tauri/tests/provider_service.rs
+++ b/src-tauri/tests/provider_service.rs
@@ -439,6 +439,100 @@ requires_openai_auth = true
 }
 
 #[test]
+fn provider_service_add_codex_preserves_provider_extension_fields_in_live_config() {
+    let _guard = test_mutex().lock().expect("acquire test mutex");
+    reset_test_fs();
+    let _home = ensure_test_home();
+
+    write_codex_live_atomic(
+        &json!({}),
+        Some(
+            r#"model_provider = "rightcode"
+model = "gpt-5.4"
+
+[model_providers.rightcode]
+name = "RightCode"
+base_url = "https://rightcode.example/v1"
+wire_api = "responses"
+requires_openai_auth = true
+"#,
+        ),
+    )
+    .expect("seed codex config");
+
+    let state = create_test_state().expect("create test state");
+    let provider = Provider::with_id(
+        "new-provider".to_string(),
+        "New Provider".to_string(),
+        json!({
+            "auth": {},
+            "config": r#"model_provider = "codex_sub"
+model = "gpt-5.5"
+model_reasoning_effort = "high"
+
+[model_providers.codex_sub]
+name = "codex_sub"
+base_url = "https://api.tu-zi.com/coding"
+env_key = "CODEX_SUB_CODEX_API_KEY"
+wire_api = "chat"
+requires_openai_auth = false
+request_max_retries = 4
+stream_idle_timeout_ms = 300000
+
+[model_providers.codex_sub.headers]
+X-Custom-Trace = "keep-me"
+"#
+        }),
+        Some("aggregator".to_string()),
+    );
+
+    ProviderService::add(&state, AppType::Codex, provider, false).expect("add codex provider");
+
+    let config_text = std::fs::read_to_string(tuzi_switch_lib::get_codex_config_path())
+        .expect("read codex config");
+    let parsed: toml::Value = toml::from_str(&config_text).expect("parse config");
+    let provider = parsed
+        .get("model_providers")
+        .and_then(|value| value.get("codex_sub"))
+        .expect("codex_sub provider should be registered");
+
+    assert_eq!(
+        provider
+            .get("request_max_retries")
+            .and_then(|value| value.as_integer()),
+        Some(4),
+        "Codex provider retry tuning should be preserved"
+    );
+    assert_eq!(
+        provider
+            .get("stream_idle_timeout_ms")
+            .and_then(|value| value.as_integer()),
+        Some(300000),
+        "Codex provider stream timeout should be preserved"
+    );
+    assert_eq!(
+        provider
+            .get("headers")
+            .and_then(|value| value.get("X-Custom-Trace"))
+            .and_then(|value| value.as_str()),
+        Some("keep-me"),
+        "Codex provider nested headers should be preserved"
+    );
+    assert_eq!(
+        provider.get("wire_api").and_then(|value| value.as_str()),
+        Some("chat"),
+        "Codex provider wire_api should respect provider-specific config"
+    );
+    assert_eq!(
+        provider
+            .get("requires_openai_auth")
+            .and_then(|value| value.as_bool()),
+        Some(false),
+        "Codex provider auth mode should respect provider-specific config"
+    );
+}
+
+#[test]
 fn provider_service_add_codex_tuzi_route_uses_numbered_provider_without_overwriting_existing_tuzi()
 {
     let _guard = test_mutex().lock().expect("acquire test mutex");

--- a/tests/config/hermesProviderPresets.test.ts
+++ b/tests/config/hermesProviderPresets.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from "vitest";
 import { hermesProviderPresets } from "@/config/hermesProviderPresets";
 
 describe("Hermes provider presets", () => {
-  it("should expose only the requested presets", () => {
-    expect(hermesProviderPresets.map((item) => item.name)).toEqual([
+  it("should keep tuzi-managed presets first", () => {
+    expect(hermesProviderPresets.slice(0, 5).map((item) => item.name)).toEqual([
       "codex-tuzi",
       "codex-coding",
       "codex-gaccode",


### PR DESCRIPTION
## 问题描述

Codex 新版配置已经把自定义厂商集中在 `[model_providers.<id>]`，并允许 headers、query params、重试、超时、鉴权模式等扩展字段。此前 tuzi-switch 在保存或登记 Codex 供应商时会重建固定字段，容易丢失这些扩展配置；带嵌套子表的供应商重复保存时，还可能残留旧子表导致 TOML 重复 table。Gemini .env 对特殊字符也缺少安全转义，Hermes 预设测试与当前已扩展的预设列表不一致。

## 修复思路

- Codex 新增带原始 provider config 的 route 保存路径，保留同 route 下未知字段、headers 子表、重试/超时等扩展配置。
- `wire_api` 和 `requires_openai_auth` 改为缺失时补默认，已有时尊重厂商配置。
- 非当前 Codex 供应商登记、当前供应商 live 写入、保存入口都接入同一保留逻辑。
- section 清理支持 `[model_providers.<id>.*]` 嵌套子表，避免重复 table。
- Gemini .env 增加特殊字符转义/反转义。
- Hermes 预设测试改为验证 tuzi 管理预设仍在前 5 个，同时允许新增厂商预设。

## 更新代码架构

- `src-tauri/src/codex_config.rs`：新增 `save_route_to_config_with_provider_config`、provider section 提取/构造、嵌套 section 清理及回归测试。
- `src-tauri/src/services/provider/live.rs`、`src-tauri/src/commands/config.rs`：接入 Codex 扩展字段保留路径。
- `src-tauri/src/gemini_config.rs`：新增 .env 安全序列化。
- `src-tauri/tests/provider_service.rs`、`tests/config/hermesProviderPresets.test.ts`：补关键路径测试。
- `docs/`、`qa/`：补交接文档和人工测试文档。

## 验证

- `cargo fmt --check`
- `cargo check`
- `cargo test --test provider_service codex -- --nocapture --test-threads=1`
- `cargo test gemini_config::tests -- --nocapture --test-threads=1`
- `pnpm -s exec tsc --noEmit`
- `pnpm -s exec vitest run tests/config/hermesProviderPresets.test.ts`
- `git diff --check`
