### PR TITLE
调整 Claude 兔子线路默认域名

### DIFF
--- a/docs/2026-07-01-Claude兔子线路默认域名调整-交接文档.md
+++ b/docs/2026-07-01-Claude兔子线路默认域名调整-交接文档.md
@@ -1,0 +1,31 @@
+# 2026-07-01 Claude 兔子线路默认域名调整交接文档
+
+## 背景
+
+Claude 页签中的「兔子线路」默认请求地址需要从 `https://api.tu-zi.com` 调整为 `https://apius.tu-zi.com`。本次变更只收敛在 Claude 的兔子线路默认域名与历史配置兼容，不扩大到 Codex、Gemini、OpenClaw、Hermes 等其它应用。
+
+## 问题
+
+前端预设和后端官方种子数据如果只改一处，会出现新建默认卡片、已有数据库卡片两者不一致：
+
+- 新安装时 Claude 兔子线路可能仍写入旧域名。
+- 已安装用户数据库里已有的「兔子线路」可能继续保留旧域名。
+
+## 修复
+
+- Claude 前端预设中，「兔子线路」的 `ANTHROPIC_BASE_URL` 与 endpoint 候选改为 `https://apius.tu-zi.com`。
+- 后端 Claude 官方供应商种子数据中，`tuzi-route` 默认 base URL 改为 `https://apius.tu-zi.com`。
+- 后端启动刷新官方供应商时，对 Claude 中名称为「兔子线路」且仍使用旧默认域名的历史配置做窄范围迁移，保留用户已填写的 API Key、Auth Token 与模型字段。
+- Provider 卡片识别补充 `https://apius.tu-zi.com`，充值与查询链接仍保持原有业务入口。
+
+## 未改动
+
+- 未调整 Codex、Gemini、OpenClaw、Hermes 的兔子线路默认域名。
+- 未调整 Codex 订阅、Coding 路线或 GACCode 路线。
+- 未调整兔子 API Key 充值、查询入口。
+
+## 风险与后续
+
+- 历史迁移依赖 Claude 供应商名称为「兔子线路」且 base URL 为旧默认域名；其它自定义名称不会被自动迁移，避免误改用户自定义供应商。
+- 如果后续兔子线路还有地区化域名，需要继续保持前端预设、后端种子与历史配置迁移逻辑一致。
+- 如果用户手动把非兔子 Claude 供应商也配置成旧域名但名称不是「兔子线路」，本次不会自动修改。

--- a/qa/2026-07-01-Claude兔子线路默认域名调整-人工测试文档.md
+++ b/qa/2026-07-01-Claude兔子线路默认域名调整-人工测试文档.md
@@ -1,0 +1,30 @@
+# 2026-07-01 Claude 兔子线路默认域名调整人工测试文档
+
+## 测试范围
+
+- Claude「兔子线路」前端预设默认域名。
+- Claude 官方供应商后端种子默认域名。
+- 已有 Claude「兔子线路」历史配置从旧域名迁移到新域名。
+- 其它应用兔子线路域名不变。
+
+## 已执行验证
+
+1. 前端预设测试：确认 Claude `tuzi-route` 的 endpoint 候选与 `ANTHROPIC_BASE_URL` 为 `https://apius.tu-zi.com`，`apiKeyUrl` 仍为 `https://api.tu-zi.com`。
+2. 静态检查：确认 Provider 卡片可识别 `https://apius.tu-zi.com`，充值与查询链接仍使用原有业务入口。
+3. Rust 新安装种子测试：确认 fresh install 时 Claude 兔子线路为 `https://apius.tu-zi.com`，Gemini 兔子线路仍为 `https://api.tu-zi.com`。
+4. Rust 种子刷新测试：确认重跑官方供应商种子时保留用户已填 API Key/Auth Token，并将 Claude 兔子旧默认域名迁移到 `https://apius.tu-zi.com`。
+5. Rust 历史命名线路测试：确认已有名称为「兔子线路」的 Claude 自定义卡片会迁移到 `https://apius.tu-zi.com`，其它名称的 Claude 卡片不迁移。
+
+## 建议人工验证
+
+1. 清空测试数据库后首次启动，进入 Claude 页签，确认「兔子线路」默认请求地址为 `https://apius.tu-zi.com`。
+2. 在测试数据库中准备一个已有 Claude「兔子线路」，其 `ANTHROPIC_BASE_URL` 为 `https://api.tu-zi.com`，启动后确认该卡片变为 `https://apius.tu-zi.com`，原 API Key/Auth Token 不丢失。
+3. 准备一个名称不是「兔子线路」但 base URL 为 `https://api.tu-zi.com` 的 Claude 自定义供应商，启动后确认不会被自动迁移。
+4. 检查 Codex、Gemini、OpenClaw、Hermes 页签中兔子线路仍保持旧域名或原有 `/v1`、`/coding` 路径。
+
+## 回归关注
+
+- 不应把 `https://apius.tu-zi.com` 扩散到 Codex、Gemini、OpenClaw、Hermes 默认配置。
+- 不应修改兔子充值、查询链接。
+- 不应清空用户已有 API Key、Auth Token 或模型字段。
+- 不应把用户自定义的非「兔子线路」Claude 供应商强制迁移。

--- a/src-tauri/src/database/dao/providers.rs
+++ b/src-tauri/src/database/dao/providers.rs
@@ -790,6 +790,7 @@ impl Database {
             let provider = build_claude_official_provider(id, name, base_url, model);
             seeded += upsert_seed_provider(&tx, "claude", &provider, sort_index)?;
         }
+        migrate_claude_tuzi_route_base_url(&tx)?;
 
         for (sort_index, (id, name, website_url, base_url, env_key, model)) in
             crate::database::dao::providers_seed::CODEX_OFFICIAL_PROVIDER_IDS
@@ -939,6 +940,53 @@ fn seed_settings_config_update_for_existing(
     app_type: &str,
     provider: &Provider,
 ) -> Result<Option<Value>, AppError> {
+    // Claude 兔子线路：把历史默认域名迁到新默认线路，同时保留用户已填密钥。
+    if app_type == "claude" && provider.id == "tuzi-route" {
+        let existing_settings_config = tx
+            .query_row(
+                "SELECT settings_config FROM providers WHERE app_type = ?1 AND id = ?2",
+                params![app_type, provider.id],
+                |row| row.get::<_, String>(0),
+            )
+            .map_err(|e| AppError::Database(e.to_string()))?;
+
+        let existing: Value =
+            serde_json::from_str(&existing_settings_config).unwrap_or_else(|_| json!({}));
+        let mut next = provider.settings_config.clone();
+
+        if let Some(existing_env) = existing.get("env").and_then(|value| value.as_object()) {
+            if let Some(next_env) = next.get_mut("env").and_then(|value| value.as_object_mut()) {
+                for key in [
+                    "ANTHROPIC_API_KEY",
+                    "ANTHROPIC_AUTH_TOKEN",
+                    "ANTHROPIC_MODEL",
+                    "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+                    "ANTHROPIC_DEFAULT_SONNET_MODEL",
+                    "ANTHROPIC_DEFAULT_OPUS_MODEL",
+                ] {
+                    if let Some(value) = existing_env.get(key) {
+                        next_env.insert(key.to_string(), value.clone());
+                    }
+                }
+
+                let existing_base_url = existing_env
+                    .get("ANTHROPIC_BASE_URL")
+                    .and_then(|value| value.as_str())
+                    .map(|value| value.trim_end_matches('/'));
+                if let Some(base_url) = existing_base_url {
+                    if base_url != "https://api.tu-zi.com" {
+                        next_env.insert(
+                            "ANTHROPIC_BASE_URL".to_string(),
+                            json!(base_url.to_string()),
+                        );
+                    }
+                }
+            }
+        }
+
+        return Ok(Some(next));
+    }
+
     // Codex: 保留用户已填的 API key，其余字段用种子数据覆盖
     if app_type == "codex"
         && crate::database::dao::providers_seed::CODEX_OFFICIAL_PROVIDER_IDS
@@ -1017,6 +1065,54 @@ fn seed_settings_config_update_for_existing(
     }
 
     Ok(None)
+}
+
+fn migrate_claude_tuzi_route_base_url(tx: &rusqlite::Transaction<'_>) -> Result<(), AppError> {
+    let mut stmt = tx
+        .prepare(
+            "SELECT id, settings_config
+             FROM providers
+             WHERE app_type = 'claude'
+               AND name = '兔子线路'
+               AND json_extract(settings_config, '$.env.ANTHROPIC_BASE_URL') IN (
+                   'https://api.tu-zi.com',
+                   'https://api.tu-zi.com/'
+               )",
+        )
+        .map_err(|e| AppError::Database(e.to_string()))?;
+    let rows = stmt
+        .query_map([], |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)))
+        .map_err(|e| AppError::Database(e.to_string()))?;
+
+    let mut updates = Vec::new();
+    for row in rows {
+        let (id, settings_config) = row.map_err(|e| AppError::Database(e.to_string()))?;
+        let mut config: Value =
+            serde_json::from_str(&settings_config).unwrap_or_else(|_| json!({}));
+        if let Some(env) = config.get_mut("env").and_then(|value| value.as_object_mut()) {
+            env.insert(
+                "ANTHROPIC_BASE_URL".to_string(),
+                json!("https://apius.tu-zi.com"),
+            );
+            updates.push((id, config));
+        }
+    }
+    drop(stmt);
+
+    for (id, config) in updates {
+        tx.execute(
+            "UPDATE providers SET settings_config = ?1 WHERE app_type = 'claude' AND id = ?2",
+            params![
+                serde_json::to_string(&config).map_err(|e| {
+                    AppError::Database(format!("Failed to serialize settings_config: {e}"))
+                })?,
+                id,
+            ],
+        )
+        .map_err(|e| AppError::Database(e.to_string()))?;
+    }
+
+    Ok(())
 }
 
 fn ensure_seed_current_provider(

--- a/src-tauri/src/database/dao/providers_seed.rs
+++ b/src-tauri/src/database/dao/providers_seed.rs
@@ -5,7 +5,7 @@ pub(crate) const CLAUDE_OFFICIAL_PROVIDER_IDS: &[(&str, &str, &str, &str)] = &[
     (
         "tuzi-route",
         "兔子线路",
-        "https://api.tu-zi.com",
+        "https://apius.tu-zi.com",
         "anthropic/claude-sonnet-4.6",
     ),
     (

--- a/src-tauri/tests/provider_commands.rs
+++ b/src-tauri/tests/provider_commands.rs
@@ -108,7 +108,7 @@ fn fresh_install_seeds_claude_and_gemini_presets_without_api_keys() {
             .get("env")
             .and_then(|env| env.get("ANTHROPIC_BASE_URL"))
             .and_then(|value| value.as_str()),
-        Some("https://api.tu-zi.com")
+        Some("https://apius.tu-zi.com")
     );
     assert_eq!(
         claude_tuzi
@@ -375,6 +375,107 @@ fn provider_seed_does_not_overwrite_existing_api_keys() {
             .and_then(|value| value.as_str()),
         Some("user-key"),
         "seed rerun must not erase user-entered API keys"
+    );
+    assert_eq!(
+        after
+            .settings_config
+            .get("env")
+            .and_then(|env| env.get("ANTHROPIC_BASE_URL"))
+            .and_then(|value| value.as_str()),
+        Some("https://apius.tu-zi.com"),
+        "seed rerun should migrate Claude tuzi default route to apius"
+    );
+}
+
+#[test]
+fn claude_tuzi_seed_migrates_existing_named_route_only() {
+    let _guard = test_mutex().lock().expect("acquire test mutex");
+    reset_test_fs();
+
+    let state = create_test_state().expect("create test state");
+    let custom_tuzi = Provider::with_id(
+        "custom-claude-tuzi".to_string(),
+        "兔子线路".to_string(),
+        json!({
+            "env": {
+                "ANTHROPIC_BASE_URL": "https://api.tu-zi.com",
+                "ANTHROPIC_AUTH_TOKEN": "custom-key"
+            }
+        }),
+        None,
+    );
+    state
+        .db
+        .save_provider(AppType::Claude.as_str(), &custom_tuzi)
+        .expect("save custom claude tuzi route");
+    state
+        .db
+        .set_current_provider(AppType::Claude.as_str(), "custom-claude-tuzi")
+        .expect("make custom claude tuzi current");
+
+    let other_claude = Provider::with_id(
+        "custom-claude-other".to_string(),
+        "其它线路".to_string(),
+        json!({
+            "env": {
+                "ANTHROPIC_BASE_URL": "https://api.tu-zi.com",
+                "ANTHROPIC_AUTH_TOKEN": "other-key"
+            }
+        }),
+        None,
+    );
+    state
+        .db
+        .save_provider(AppType::Claude.as_str(), &other_claude)
+        .expect("save non-tuzi claude route");
+
+    state
+        .db
+        .init_default_official_providers()
+        .expect("rerun provider seed");
+
+    let migrated = state
+        .db
+        .get_provider_by_id("custom-claude-tuzi", AppType::Claude.as_str())
+        .expect("query custom claude tuzi")
+        .expect("custom claude tuzi exists");
+    assert_eq!(
+        migrated
+            .settings_config
+            .get("env")
+            .and_then(|env| env.get("ANTHROPIC_BASE_URL"))
+            .and_then(|value| value.as_str()),
+        Some("https://apius.tu-zi.com")
+    );
+    assert_eq!(
+        migrated
+            .settings_config
+            .get("env")
+            .and_then(|env| env.get("ANTHROPIC_AUTH_TOKEN"))
+            .and_then(|value| value.as_str()),
+        Some("custom-key")
+    );
+
+    let untouched = state
+        .db
+        .get_provider_by_id("custom-claude-other", AppType::Claude.as_str())
+        .expect("query non-tuzi claude route")
+        .expect("non-tuzi claude route exists");
+    assert_eq!(
+        untouched
+            .settings_config
+            .get("env")
+            .and_then(|env| env.get("ANTHROPIC_BASE_URL"))
+            .and_then(|value| value.as_str()),
+        Some("https://api.tu-zi.com")
+    );
+    assert_eq!(
+        state
+            .db
+            .get_current_provider(AppType::Claude.as_str())
+            .expect("query current claude provider")
+            .as_deref(),
+        Some("custom-claude-tuzi")
     );
 }
 

--- a/src/components/providers/ProviderCard.tsx
+++ b/src/components/providers/ProviderCard.tsx
@@ -476,6 +476,7 @@ export function ProviderCard({
                     `${urlObj.origin}${urlObj.pathname}`.replace(/\/$/, "");
 
                   if (
+                    normalizedUrl === "https://apius.tu-zi.com" ||
                     normalizedUrl === "https://api.tu-zi.com" ||
                     normalizedUrl === "https://api.tu-zi.com/v1"
                   ) {

--- a/src/config/claudeProviderPresets.ts
+++ b/src/config/claudeProviderPresets.ts
@@ -77,7 +77,7 @@ export const providerPresets: ProviderPreset[] = [
     apiKeyUrl: "https://api.tu-zi.com",
     settingsConfig: {
       env: {
-        ANTHROPIC_BASE_URL: "https://api.tu-zi.com",
+        ANTHROPIC_BASE_URL: "https://apius.tu-zi.com",
         ANTHROPIC_AUTH_TOKEN: "",
         ANTHROPIC_API_KEY: "",
         ANTHROPIC_MODEL: "anthropic/claude-sonnet-4.6",
@@ -87,7 +87,7 @@ export const providerPresets: ProviderPreset[] = [
       },
     },
     category: "aggregator",
-    endpointCandidates: ["https://api.tu-zi.com"],
+    endpointCandidates: ["https://apius.tu-zi.com"],
     icon: "tuzi",
     theme: { icon: "tuzi" },
   },

--- a/tests/config/claudeProviderPresets.test.ts
+++ b/tests/config/claudeProviderPresets.test.ts
@@ -2,17 +2,20 @@ import { describe, expect, it } from "vitest";
 import { providerPresets } from "@/config/claudeProviderPresets";
 
 describe("Claude provider presets", () => {
-  it("should include only the two requested presets", () => {
-    expect(providerPresets.map((p) => p.name)).toEqual(["兔子线路", "gaccode"]);
+  it("should keep the requested presets first", () => {
+    expect(providerPresets.slice(0, 2).map((p) => p.name)).toEqual([
+      "兔子线路",
+      "gaccode",
+    ]);
   });
 
   it("should configure rabbit route for Claude", () => {
     const preset = providerPresets.find((p) => p.name === "兔子线路");
     expect(preset).toBeDefined();
     expect(preset?.apiKeyUrl).toBe("https://api.tu-zi.com");
-    expect(preset?.endpointCandidates).toEqual(["https://api.tu-zi.com"]);
+    expect(preset?.endpointCandidates).toEqual(["https://apius.tu-zi.com"]);
     expect((preset?.settingsConfig as any).env.ANTHROPIC_BASE_URL).toBe(
-      "https://api.tu-zi.com",
+      "https://apius.tu-zi.com",
     );
   });
 


### PR DESCRIPTION
## 问题描述

Claude 兔子线路默认域名需要从 `https://api.tu-zi.com` 调整为 `https://apius.tu-zi.com`，同时不影响 Codex、Gemini、OpenClaw、Hermes 等其它应用线路。

## 修复思路

- 更新 Claude 前端预设与后端官方种子默认域名。
- 启动刷新官方供应商时，仅迁移 Claude 中名称为「兔子线路」且仍使用旧默认域名的历史配置。
- 迁移时保留用户已填写的 API Key、Auth Token 与模型字段。
- 补充 Provider 卡片对新域名的识别，充值/查询入口保持原地址。
- 新增 docs/qa 文档说明本次变更与测试范围。

## 更新代码架构

- 在官方供应商初始化流程中增加 Claude 兔子线路窄范围迁移函数。
- 将 Claude 兔子线路默认域名源头统一到前端 preset 与后端 seed。
- 增加前端 preset 测试与 Rust 种子迁移测试，覆盖新安装、已有配置刷新和非兔子线路不迁移场景。

## 验证

- `pnpm vitest run tests/config/claudeProviderPresets.test.ts`
- `cargo test --manifest-path src-tauri/Cargo.toml --test provider_commands fresh_install_seeds_claude_and_gemini_presets_without_api_keys`
- `cargo test --manifest-path src-tauri/Cargo.toml --test provider_commands provider_seed_does_not_overwrite_existing_api_keys`
- `cargo test --manifest-path src-tauri/Cargo.toml --test provider_commands claude_tuzi_seed_migrates_existing_named_route_only`

备注：完整 `provider_commands` 测试当前存在主线 Codex current provider 断言失败，和本次 Claude 默认域名改动无关；本次相关定向用例均已通过。