### PR TITLE
修复 Codex 供应商 Key 隔离

### DIFF
--- a/docs/bugfix-codex-provider-apikey-cross-write.md
+++ b/docs/bugfix-codex-provider-apikey-cross-write.md
@@ -55,3 +55,65 @@ Codex 官方供应商必须保持“一张供应商卡片一个独立 envKey”�
 - 缺失 `env_key` 的旧配置会恢复到供应商专属 envKey。
 - Codex 切换供应商后，live config 使用正确 token。
 - Codex backfill 后，provider 自己的 `model_provider` 和 `[profiles.*]` override 仍可恢复。
+
+## 2026-07-15 补充：live 回填与复制供应商串号
+
+### 新增现象
+
+1. 用户只修改测试线路配置后，切换其他 Codex 线路时，当前 Codex 线路卡片的 Key 被自动改成测试线路 Key。
+2. 复制 `codex订阅_2` 后，多个 `copy` 卡片展示同一个脱敏 Key；编辑任一副本会影响同一个凭据位置。
+
+这两个现象都表现为“Key 被覆盖”，但来源不同：
+
+- 切换串号来自 live config backfill 将当前运行态 Key 回写到错误 provider。
+- 复制串号来自 duplicate provider 时复用了原 provider 的 `env_key`。
+
+### 根因拆分
+
+#### live backfill 串号
+
+Codex 切换线路后，应用会从 `~/.codex/config.toml` 回填当前 live Key，目的是让卡片展示运行态凭据。
+
+旧逻辑没有严格区分“运行态 live config”和“provider 编辑态 SSOT”：
+
+- live config 里可能包含当前正在使用的 `env_key` 或 `experimental_bearer_token`。
+- provider 模板本身也有自己的 `env_key`。
+- 当 live envKey 与模板 envKey 不一致时，旧逻辑仍可能把 live token 回填到模板 provider，导致 A 线路显示或保存成 B 线路的 Key。
+
+#### duplicate provider 串号
+
+Codex API Key 使用 env-first 模型，真实 Key 不直接存在卡片配置里，而是通过 `env_key` 指向受管理环境变量。
+
+旧复制逻辑深拷贝了 `settingsConfig`，但没有为新副本生成独立 `env_key`：
+
+- 原 provider：`CODING_CODEX_API_KEY`
+- 副本 provider：仍是 `CODING_CODEX_API_KEY`
+
+因此多个副本实际共享同一个环境变量。用户改任意一个副本，本质上都在改同一个 Key。
+
+### 修复原则
+
+1. live config 只能作为当前运行状态参考，不能无条件覆盖 provider 编辑态配置。
+2. 回填时必须保留 provider 模板自身的 `env_key`。
+3. 如果 live envKey 与模板 envKey 不一致，应丢弃外来的 `experimental_bearer_token`，避免把其他线路 token 固化到当前 provider。
+4. 复制 Codex provider 时必须生成新的唯一 `env_key`。
+5. 复制出来的新 provider 不应携带原 provider 的真实 Key，也不应携带原 provider 的 `experimental_bearer_token`。
+
+### 本次补充修复
+
+- Codex restore/backfill 保留模板 provider 自身 `env_key`，并在 live envKey 不匹配时移除外来 token。
+- duplicate Codex provider 时基于副本名称生成唯一 envKey，例如 `CODEX_2_COPY_CODEX_API_KEY`，冲突时追加编号。
+- 副本配置同步更新：
+  - `settingsConfig.env.envKey`
+  - active `[model_providers.*]` section 的 `env_key`
+- 副本配置会清理：
+  - `auth.OPENAI_API_KEY`
+  - `experimental_bearer_token`
+
+### 回归验证
+
+- live backfill 不应把测试线路 Key 写回当前 Codex provider。
+- 切换线路后，provider 自身 TOML 的 `env_key` 保持不变。
+- 复制 Codex provider 后，新副本的 `env_key` 不等于原 provider。
+- 多次复制同一 Codex provider 后，每个副本的 `env_key` 都唯一。
+- 副本初始不应显示原 provider 的 Key；用户后续填写时只写入副本自己的 envKey。

--- a/qa/2026-07-15-Codex供应商Key隔离-人工测试文档.md
+++ b/qa/2026-07-15-Codex供应商Key隔离-人工测试文档.md
@@ -1,0 +1,51 @@
+# 2026-07-15 Codex 供应商 Key 隔离人工测试文档
+
+## 测试范围
+
+- Codex 供应商切换时，live config 回填不会把其他线路 Key 写回当前 provider。
+- Codex 供应商复制时，副本生成独立 `env_key`，不与原 provider 共用 Key。
+- 副本不携带原 provider 的 `experimental_bearer_token` 或旧版 `auth.OPENAI_API_KEY`。
+- 卡片 Key 展示、编辑保存、再次切换后保持 provider 级隔离。
+
+## 前置数据
+
+准备至少三个 Codex provider，并分别配置不同 Key：
+
+1. `兔子线路`：`TUZI_CODEX_API_KEY`
+2. `codex订阅`：`CODING_CODEX_API_KEY`
+3. `gaccode`：`GAC_CODEX_API_KEY`
+
+每个 envKey 对应的真实 Key 应使用不同前后缀，便于从脱敏展示判断是否串号。
+
+## 已执行验证
+
+1. 回填隔离：构造 live config 中的 envKey 与 provider 模板 envKey 不一致，执行 restore/backfill 后保留模板 envKey，并移除外来 `experimental_bearer_token`。
+2. TOML 工具函数：`setCodexEnvKey` 只更新 active provider section，不修改 inactive provider section。
+3. 复制隔离：复制 Codex provider 后生成新的唯一 envKey，并清理旧 Key 字段与 copied token。
+
+## 已执行命令
+
+```bash
+cargo test -p tu-zi-switch codex_config::tests::restore_backfill --lib
+cargo fmt --check
+pnpm vitest run tests/utils/providerConfigUtils.codex.test.ts
+pnpm exec tsc --noEmit
+pnpm exec prettier --check src/App.tsx src/utils/providerConfigUtils.ts tests/utils/providerConfigUtils.codex.test.ts
+```
+
+## 建议人工验证
+
+1. 分别给三个 Codex provider 填入不同 Key，确认卡片显示三个不同的脱敏 Key。
+2. 切换到 `codex订阅`，再切换到 `兔子线路`，确认 `兔子线路` 的 Key 没有变成 `codex订阅` 的 Key。
+3. 编辑非当前生效的测试 provider，保存后切回当前 provider，确认当前 provider 的 Key 不变。
+4. 复制 `codex订阅`，确认新副本初始不显示原 provider 的 Key。
+5. 给副本填写新 Key，保存后确认原 `codex订阅` 仍显示原 Key，副本显示新 Key。
+6. 连续复制同一个 Codex provider 多次，分别给副本填写不同 Key，确认每张卡片互不影响。
+
+## 回归关注
+
+- 不应把 live config 中的 `experimental_bearer_token` 当作其他 provider 的编辑态 Key。
+- 不应让多个 Codex provider 共享同一个 `env_key`，除非用户显式编辑成同一个高级配置。
+- 不应为了卡片回显把真实 Key 写回 `auth.OPENAI_API_KEY`。
+- 不应影响 Codex 官方登录或 OAuth 类 provider 的登录态保留逻辑。
+- 不应影响 OpenCode、OpenClaw、Hermes 的 provider 复制逻辑。

--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -753,6 +753,66 @@ fn extract_codex_env_key(config_text: &str) -> Option<String> {
         .map(str::to_string)
 }
 
+fn codex_active_provider_env_key_state(
+    config_text: &str,
+) -> Result<Option<Option<String>>, AppError> {
+    if config_text.trim().is_empty() {
+        return Ok(None);
+    }
+
+    let doc = config_text
+        .parse::<DocumentMut>()
+        .map_err(|e| AppError::Message(format!("Invalid Codex config.toml: {e}")))?;
+    let Some(provider_id) = active_codex_model_provider_id(&doc) else {
+        return Ok(None);
+    };
+    let Some(provider_table) = codex_active_provider_table(&doc, &provider_id) else {
+        return Ok(None);
+    };
+
+    let env_key = provider_table
+        .get("env_key")
+        .and_then(|item| item.as_str())
+        .map(str::trim)
+        .filter(|env_key| !env_key.is_empty())
+        .map(str::to_string);
+
+    Ok(Some(env_key))
+}
+
+fn set_codex_active_provider_env_key(
+    config_text: &str,
+    env_key: Option<&str>,
+) -> Result<String, AppError> {
+    if config_text.trim().is_empty() {
+        return Ok(config_text.to_string());
+    }
+
+    let mut doc = config_text
+        .parse::<DocumentMut>()
+        .map_err(|e| AppError::Message(format!("Invalid Codex config.toml: {e}")))?;
+    let Some(provider_id) = active_codex_model_provider_id(&doc) else {
+        return Ok(config_text.to_string());
+    };
+    let Some(provider_table) = doc
+        .get_mut("model_providers")
+        .and_then(|item| item.as_table_mut())
+        .and_then(|table| table.get_mut(provider_id.as_str()))
+        .and_then(|item| item.as_table_mut())
+    else {
+        return Ok(config_text.to_string());
+    };
+
+    if let Some(env_key) = env_key {
+        validate_env_key_name(env_key)?;
+        provider_table["env_key"] = toml_edit::value(env_key);
+    } else {
+        provider_table.remove("env_key");
+    }
+
+    Ok(doc.to_string())
+}
+
 pub fn extract_codex_experimental_bearer_token(config_text: &str) -> Option<String> {
     if !config_text.contains("experimental_bearer_token") {
         return None;
@@ -1286,12 +1346,53 @@ pub fn restore_codex_settings_config_model_provider_for_backfill(
         return Ok(());
     };
 
-    let restored = restore_codex_backfill_model_provider_id(&config_text, template_config_text)?;
+    let live_env_key = extract_codex_env_key(&config_text);
+    let template_env_key_state = codex_active_provider_env_key_state(template_config_text)?;
+    let mut restored =
+        restore_codex_backfill_model_provider_id(&config_text, template_config_text)?;
+
+    if let Some(template_env_key) = template_env_key_state {
+        restored = set_codex_active_provider_env_key(&restored, template_env_key.as_deref())?;
+        if live_env_key != template_env_key {
+            restored = remove_codex_experimental_bearer_token(&restored)?;
+        }
+    }
+
     if let Some(obj) = settings.as_object_mut() {
         obj.insert("config".to_string(), Value::String(restored));
     }
 
     Ok(())
+}
+
+fn restore_codex_stored_credentials_for_backfill(settings: &mut Value, template_settings: &Value) {
+    let Some(obj) = settings.as_object_mut() else {
+        return;
+    };
+
+    match template_settings
+        .get("env")
+        .filter(|value| value.is_object())
+    {
+        Some(env) => {
+            obj.insert("env".to_string(), env.clone());
+        }
+        None => {
+            obj.remove("env");
+        }
+    }
+
+    match template_settings
+        .get("auth")
+        .filter(|value| value.is_object())
+    {
+        Some(auth) => {
+            obj.insert("auth".to_string(), auth.clone());
+        }
+        None => {
+            obj.remove("auth");
+        }
+    }
 }
 
 pub fn restore_codex_provider_token_for_backfill(
@@ -1366,6 +1467,7 @@ pub fn restore_codex_settings_for_backfill(
     restore_provider_token: bool,
 ) -> Result<(), AppError> {
     restore_codex_settings_config_model_provider_for_backfill(settings, template_settings)?;
+    restore_codex_stored_credentials_for_backfill(settings, template_settings);
     if restore_provider_token {
         restore_codex_provider_token_for_backfill(settings, template_settings)?;
     }
@@ -2428,6 +2530,50 @@ env_key = "TUZI_BACKFILL_CODEX_API_KEY"
                 "TUZI_BACKFILL_CODEX_API_KEY".to_string(),
                 "sk-backfill".to_string()
             )]
+        );
+    }
+
+    #[test]
+    fn restore_backfill_drops_foreign_live_token_and_keeps_template_env_key() {
+        let mut live_settings = json!({
+            "auth": {},
+            "env": { "envKey": "TUZI03_CODEX_API_KEY" },
+            "config": r#"model_provider = "vendor_alpha"
+
+[model_providers.vendor_alpha]
+env_key = "TUZI03_CODEX_API_KEY"
+experimental_bearer_token = "sk-test-line"
+"#
+        });
+        let template_settings = json!({
+            "auth": {},
+            "env": { "envKey": "CODING03_CODEX_API_KEY" },
+            "config": r#"model_provider = "vendor_alpha"
+
+[model_providers.vendor_alpha]
+env_key = "CODING03_CODEX_API_KEY"
+"#
+        });
+
+        restore_codex_settings_for_backfill(&mut live_settings, &template_settings, true).unwrap();
+
+        let config = live_settings.get("config").and_then(Value::as_str).unwrap();
+        let parsed: toml::Value = toml::from_str(config).unwrap();
+        assert_eq!(
+            parsed
+                .get("model_providers")
+                .and_then(|value| value.get("vendor_alpha"))
+                .and_then(|value| value.get("env_key"))
+                .and_then(|value| value.as_str()),
+            Some("CODING03_CODEX_API_KEY")
+        );
+        assert!(
+            !config.contains("experimental_bearer_token"),
+            "foreign live token must not be saved into the previous provider"
+        );
+        assert_eq!(
+            live_settings.pointer("/env/envKey").and_then(Value::as_str),
+            Some("CODING03_CODEX_API_KEY")
         );
     }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -89,6 +89,11 @@ import ToolsPanel from "@/components/openclaw/ToolsPanel";
 import AgentsDefaultsPanel from "@/components/openclaw/AgentsDefaultsPanel";
 import OpenClawHealthBanner from "@/components/openclaw/OpenClawHealthBanner";
 import HermesMemoryPanel from "@/components/hermes/HermesMemoryPanel";
+import {
+  generateCodexCopyEnvKey,
+  getCodexProviderEnvKeyFromSettings,
+  rewriteDuplicatedCodexSettingsConfig,
+} from "@/utils/providerConfigUtils";
 
 type View =
   | "providers"
@@ -209,25 +214,33 @@ function App() {
   // 切换到 Codex 时，自动把 ~/.codex 里的 API key 回填到对应的预设卡片
   useEffect(() => {
     if (activeApp !== "codex") return;
-    invoke("sync_codex_live_api_key").then(() => {
-      queryClient.invalidateQueries({ queryKey: ["providers", "codex"] });
-    }).catch(() => {/* 静默失败，不影响正常使用 */});
+    invoke("sync_codex_live_api_key")
+      .then(() => {
+        queryClient.invalidateQueries({ queryKey: ["providers", "codex"] });
+      })
+      .catch(() => {
+        /* 静默失败，不影响正常使用 */
+      });
   }, [activeApp]);
 
   // 切换到 Claude 时，自动把 ~/.claude/settings.json 里的 API key 回填到对应的预设卡片
   useEffect(() => {
     if (activeApp !== "claude") return;
-    invoke("sync_claude_live_api_key").then(() => {
-      queryClient.invalidateQueries({ queryKey: ["providers", "claude"] });
-    }).catch(() => {});
+    invoke("sync_claude_live_api_key")
+      .then(() => {
+        queryClient.invalidateQueries({ queryKey: ["providers", "claude"] });
+      })
+      .catch(() => {});
   }, [activeApp]);
 
   // 切换到 Gemini 时，自动把 ~/.gemini/.env 里的 API key 回填到对应的预设卡片
   useEffect(() => {
     if (activeApp !== "gemini") return;
-    invoke("sync_gemini_live_api_key").then(() => {
-      queryClient.invalidateQueries({ queryKey: ["providers", "gemini"] });
-    }).catch(() => {});
+    invoke("sync_gemini_live_api_key")
+      .then(() => {
+        queryClient.invalidateQueries({ queryKey: ["providers", "gemini"] });
+      })
+      .catch(() => {});
   }, [activeApp]);
 
   // Fallback from sessions view when switching to an app without session support
@@ -755,6 +768,20 @@ function App() {
       icon: provider.icon,
       iconColor: provider.iconColor,
     };
+
+    if (activeApp === "codex") {
+      const existingEnvKeys = Object.values(providers)
+        .map((item) => getCodexProviderEnvKeyFromSettings(item.settingsConfig))
+        .filter(Boolean);
+      const nextEnvKey = generateCodexCopyEnvKey(
+        duplicatedProvider.name,
+        existingEnvKeys,
+      );
+      duplicatedProvider.settingsConfig = rewriteDuplicatedCodexSettingsConfig(
+        duplicatedProvider.settingsConfig,
+        nextEnvKey,
+      );
+    }
 
     if (
       activeApp === "opencode" ||

--- a/src/utils/providerConfigUtils.ts
+++ b/src/utils/providerConfigUtils.ts
@@ -468,6 +468,8 @@ const TOML_MODEL_PROVIDER_LINE_PATTERN =
   /^\s*model_provider\s*=\s*(["'])([^"'\r\n]+)\1\s*(?:#.*)?$/;
 const TOML_ENV_KEY_PATTERN =
   /^\s*env_key\s*=\s*(["'])([^"'\r\n]+)\1\s*(?:#.*)?$/;
+const TOML_ENV_KEY_REPLACE_PATTERN =
+  /^(\s*env_key\s*=\s*)(?:"(?:\\.|[^"\\\r\n])*"|'[^'\r\n]*')(\s*(?:#.*)?)$/;
 const CODEX_RESERVED_MODEL_PROVIDER_IDS = new Set([
   "amazon-bedrock",
   "openai",
@@ -1339,6 +1341,122 @@ export const removeCodexTopLevelField = (
     lines.splice(existing.index, 1);
   }
   return finalizeTomlText(lines);
+};
+
+export const setCodexEnvKey = (configText: string, envKey: string): string => {
+  const normalizedText = normalizeTomlText(configText);
+  if (!normalizedText) return configText;
+
+  const trimmed = envKey.trim();
+  if (!trimmed) return configText;
+
+  const lines = normalizedText.split("\n");
+  const escaped = escapeTomlBasicString(trimmed);
+  const targetSectionName = getCodexProviderSectionName(normalizedText);
+
+  if (targetSectionName) {
+    const sectionRange = getTomlSectionRange(lines, targetSectionName);
+    if (sectionRange) {
+      const envKeyLineIndex = findTomlLineInRange(
+        lines,
+        TOML_ENV_KEY_REPLACE_PATTERN,
+        sectionRange.bodyStartIndex,
+        sectionRange.bodyEndIndex,
+      );
+
+      if (envKeyLineIndex !== -1) {
+        lines[envKeyLineIndex] = lines[envKeyLineIndex].replace(
+          TOML_ENV_KEY_REPLACE_PATTERN,
+          `$1"${escaped}"$2`,
+        );
+        return finalizeTomlText(lines);
+      }
+
+      lines.splice(
+        getTomlSectionInsertIndex(lines, sectionRange),
+        0,
+        `env_key = "${escaped}"`,
+      );
+      return finalizeTomlText(lines);
+    }
+  }
+
+  const topLevelEndIndex = getTopLevelEndIndex(lines);
+  const topLevelEnvKeyLineIndex = findTomlLineInRange(
+    lines,
+    TOML_ENV_KEY_REPLACE_PATTERN,
+    0,
+    topLevelEndIndex,
+  );
+
+  if (topLevelEnvKeyLineIndex !== -1) {
+    lines[topLevelEnvKeyLineIndex] = lines[topLevelEnvKeyLineIndex].replace(
+      TOML_ENV_KEY_REPLACE_PATTERN,
+      `$1"${escaped}"$2`,
+    );
+    return finalizeTomlText(lines);
+  }
+
+  const insertIndex =
+    getTopLevelModelProviderLineIndex(lines) !== -1
+      ? getTopLevelModelProviderLineIndex(lines) + 1
+      : topLevelEndIndex;
+  lines.splice(insertIndex, 0, `env_key = "${escaped}"`);
+  return finalizeTomlText(lines);
+};
+
+export const generateCodexCopyEnvKey = (
+  providerName: string,
+  existingEnvKeys: string[],
+): string => {
+  const sanitizedName = providerName
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-zA-Z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .replace(/_+/g, "_")
+    .toUpperCase();
+  const prefix = sanitizedName || "CUSTOM";
+  const baseEnvKey = `${prefix}_CODEX_API_KEY`;
+  const taken = new Set(
+    existingEnvKeys.map((key) => key.trim()).filter(Boolean),
+  );
+
+  if (!taken.has(baseEnvKey)) {
+    return baseEnvKey;
+  }
+
+  let counter = 2;
+  while (taken.has(`${baseEnvKey}_${counter}`)) {
+    counter += 1;
+  }
+  return `${baseEnvKey}_${counter}`;
+};
+
+export const rewriteDuplicatedCodexSettingsConfig = (
+  settingsConfig: Record<string, any>,
+  nextEnvKey: string,
+): Record<string, any> => {
+  const nextSettingsConfig = { ...settingsConfig };
+
+  if (typeof nextSettingsConfig.config === "string") {
+    const nextConfig = setCodexEnvKey(nextSettingsConfig.config, nextEnvKey);
+    nextSettingsConfig.config = updateCodexExperimentalBearerToken(
+      updateCodexExperimentalBearerToken(nextConfig, ""),
+      "",
+    );
+  }
+
+  nextSettingsConfig.auth =
+    nextSettingsConfig.auth &&
+    typeof nextSettingsConfig.auth === "object" &&
+    !Array.isArray(nextSettingsConfig.auth)
+      ? { ...nextSettingsConfig.auth }
+      : {};
+  delete nextSettingsConfig.auth.OPENAI_API_KEY;
+
+  nextSettingsConfig.env = { envKey: nextEnvKey };
+  return nextSettingsConfig;
 };
 
 /**

--- a/tests/utils/providerConfigUtils.codex.test.ts
+++ b/tests/utils/providerConfigUtils.codex.test.ts
@@ -2,15 +2,18 @@ import { describe, expect, it } from "vitest";
 import {
   extractCodexBaseUrl,
   extractCodexExperimentalBearerToken,
+  generateCodexCopyEnvKey,
   getCodexEnvKey,
   getCodexProviderEnvKeyFromSettings,
   extractCodexModelCatalogJson,
   extractCodexModelName,
   extractCodexWireApi,
   setCodexBaseUrl,
+  setCodexEnvKey,
   setCodexModelCatalogJson,
   setCodexModelName,
   setCodexWireApi,
+  rewriteDuplicatedCodexSettingsConfig,
   updateCodexExperimentalBearerToken,
 } from "@/utils/providerConfigUtils";
 
@@ -408,6 +411,61 @@ describe("Codex TOML utils", () => {
 
     expect(updateCodexExperimentalBearerToken(input, "new-token")).toBe(input);
     expect(updateCodexExperimentalBearerToken(input, "")).toBe(input);
+  });
+
+  it("updates env_key only for the active provider section", () => {
+    const input = [
+      'model_provider = "active"',
+      'env_key = "TOP_LEVEL_CODEX_KEY"',
+      "",
+      "[model_providers.inactive]",
+      'env_key = "INACTIVE_CODEX_KEY"',
+      "",
+      "[model_providers.active]",
+      'base_url = "https://active.example/v1"',
+      'env_key = "OLD_ACTIVE_CODEX_KEY" # managed',
+      "",
+    ].join("\n");
+
+    const output = setCodexEnvKey(input, "NEW_ACTIVE_CODEX_KEY");
+
+    expect(output).toContain('env_key = "NEW_ACTIVE_CODEX_KEY" # managed');
+    expect(output).toContain('env_key = "TOP_LEVEL_CODEX_KEY"');
+    expect(output).toContain('env_key = "INACTIVE_CODEX_KEY"');
+    expect(getCodexEnvKey(output)).toBe("NEW_ACTIVE_CODEX_KEY");
+  });
+
+  it("rewrites duplicated codex settings to an isolated env key", () => {
+    const nextEnvKey = generateCodexCopyEnvKey("codex订阅_2 copy", [
+      "CODING_CODEX_API_KEY",
+      "CODEX_2_COPY_CODEX_API_KEY",
+    ]);
+
+    expect(nextEnvKey).toBe("CODEX_2_COPY_CODEX_API_KEY_2");
+
+    const output = rewriteDuplicatedCodexSettingsConfig(
+      {
+        auth: { OPENAI_API_KEY: "sk-original" },
+        env: { envKey: "CODING_CODEX_API_KEY" },
+        config: [
+          'model_provider = "tuzi"',
+          'experimental_bearer_token = "top-level-token"',
+          "",
+          "[model_providers.tuzi]",
+          'base_url = "https://api.tu-zi.com/v1"',
+          'env_key = "CODING_CODEX_API_KEY"',
+          'experimental_bearer_token = "section-token"',
+          "",
+        ].join("\n"),
+      },
+      nextEnvKey,
+    );
+
+    expect(output.env.envKey).toBe("CODEX_2_COPY_CODEX_API_KEY_2");
+    expect(output.config).toContain('env_key = "CODEX_2_COPY_CODEX_API_KEY_2"');
+    expect(output.config).not.toContain("CODING_CODEX_API_KEY");
+    expect(output.config).not.toContain("experimental_bearer_token");
+    expect(output.auth.OPENAI_API_KEY).toBeUndefined();
   });
 
   it("reads, writes, and removes top-level model_catalog_json", () => {


### PR DESCRIPTION
## 问题描述

- 切换 Codex 线路时，live config 回填可能把测试线路的 token 写回当前 provider，导致当前线路 Key 被覆盖。
- 复制 Codex provider 时复用原 provider 的 env_key，多个副本实际共享同一个环境变量，编辑任一副本会影响同一个 Key。

## 修复思路

- backfill 时保留模板 provider 自身 env_key，并在 live envKey 与模板 envKey 不一致时移除外来 experimental_bearer_token。
- 复制 Codex provider 时生成唯一 env_key，同步更新 settingsConfig.env.envKey 与 active model provider section 的 env_key。
- 复制出来的新 provider 清理 auth.OPENAI_API_KEY 与 experimental_bearer_token，避免把原 provider 凭据带入副本。

## 更新代码架构

- 新增 Codex TOML env_key 更新与复制配置重写工具函数。
- App duplicate 流程复用 providerConfigUtils 的 Codex 凭据隔离逻辑。
- 补充 Rust/前端回归测试、问题复盘 docs 和人工 QA 文档。

## 验证

- cargo test -p tu-zi-switch codex_config::tests::restore_backfill --lib
- cargo fmt --check
- pnpm vitest run tests/utils/providerConfigUtils.codex.test.ts
- pnpm exec prettier --check src/App.tsx src/utils/providerConfigUtils.ts tests/utils/providerConfigUtils.codex.test.ts docs/bugfix-codex-provider-apikey-cross-write.md qa/2026-07-15-Codex供应商Key隔离-人工测试文档.md