### PR TITLE
修复 Codex 第三方默认生图配置

### DIFF
--- a/docs/2026-07-16-Codex第三方生图默认配置-交接文档.md
+++ b/docs/2026-07-16-Codex第三方生图默认配置-交接文档.md
@@ -1,0 +1,113 @@
+# 2026-07-16 Codex 第三方生图默认配置交接文档
+
+## 背景
+
+新版 Codex App 使用第三方 API 时，如果 Provider 配置了 `requires_openai_auth = false`，但没有提供非空的 `x-openai-actor-authorization` 请求头，Codex 客户端不会启用本地 `image_gen` 生图工具。
+
+此前用户需要手动修改 `~/.codex/config.toml`。本次把生图开关配置整合到 tuzi-switch 的 Codex 默认模板和自动生成入口，并将兔子相关 Codex 默认模型更新为 `gpt-5.6-sol`，让新建供应商可直接获得完整配置。
+
+## 默认配置
+
+新建兔子 Codex 供应商时，核心配置如下：
+
+```toml
+model_provider = "tuzi"
+model = "gpt-5.6-sol"
+model_reasoning_effort = "high"
+disable_response_storage = true
+
+[model_providers.tuzi]
+name = "tuzi"
+base_url = "https://api.tu-zi.com/v1"
+env_key = "TUZI_CODEX_API_KEY"
+wire_api = "responses"
+requires_openai_auth = false
+http_headers = { "x-openai-actor-authorization" = "http://coding.tu-zi.com" }
+```
+
+经过 TOML 编辑器解析和重新序列化后，请求头可能显示为等价的表结构：
+
+```toml
+[model_providers.tuzi.http_headers]
+x-openai-actor-authorization = "http://coding.tu-zi.com"
+```
+
+## 实现范围
+
+### 前端默认模板
+
+- `src/config/codexTemplates.ts`
+  - 自定义 Codex 模板默认模型改为 `gpt-5.6-sol`。
+  - 默认关闭 OpenAI 官方登录要求。
+  - 默认添加 Codex 生图启用请求头。
+- `src/config/codexProviderPresets.ts`
+  - 第三方配置生成函数默认模型改为 `gpt-5.6-sol`。
+  - 兔子线路、Codex 订阅和 GACCode 预设同步更新。
+  - 所有通过该函数生成的新第三方 Provider 默认包含生图配置。
+- `src/components/providers/forms/hooks/useCodexConfigState.ts`
+  - 旧格式配置缺失模型时使用 `gpt-5.6-sol`。
+  - 迁移生成 Provider section 时补齐生图配置。
+- `src/components/providers/forms/ProviderForm.tsx`
+  - 新建、复制和保存 Codex 路由时的兜底模型改为 `gpt-5.6-sol`。
+- `src/components/universal/UniversalProviderFormModal.tsx`
+  - 通用供应商的 Codex 默认模型、占位提示和生成配置同步更新。
+
+### 后端生成入口
+
+- `src-tauri/src/database/dao/providers.rs`
+  - Codex 官方种子 Provider 生成配置默认包含生图请求头。
+- `src-tauri/src/database/dao/providers_seed.rs`
+  - 兔子线路、Codex 订阅和 GACCode 默认模型改为 `gpt-5.6-sol`。
+- `src-tauri/src/codex_config.rs`
+  - 新建空 Codex 路由时默认使用 `gpt-5.6-sol`。
+  - 保存路由时补齐生图请求头。
+- `src-tauri/src/commands/provider.rs`
+  - 从 live API Key 自动生成 Provider 时使用新默认模型和生图配置。
+- `src-tauri/src/deeplink/provider.rs`
+  - 通过深链导入 Codex Provider 时补齐生图配置。
+- `src-tauri/src/provider.rs`
+  - 通用 Provider 转换为 Codex 配置时补齐生图配置。
+
+## 配置含义
+
+- `model = "gpt-5.6-sol"`：新建兔子相关 Codex Provider 的默认模型。
+- `requires_openai_auth = false`：第三方线路不要求 OpenAI 官方账号认证。
+- `x-openai-actor-authorization`：Codex 客户端只检查该请求头是否存在且非空，用于启用本地 `image_gen` 工具。
+- `env_key`：API Key 继续通过环境变量管理，没有把真实密钥写入 `config.toml`。
+
+## 兼容边界
+
+- 本次只改变新建、自动生成、复制或迁移补全时的默认配置。
+- 已存在的 Provider 不会被强制覆盖，用户原有模型、Endpoint 和 Key 保持不变。
+- OpenAI Official Provider 的官方认证逻辑保持不变。
+- 未给其他明确指定模型的第三方预设强制替换模型，避免破坏供应商兼容性。
+- 请求头值不包含 API Key，不新增敏感信息泄露风险。
+
+## 验证结果
+
+已执行：
+
+```bash
+pnpm vitest run tests/config/codexDefaultConfig.test.ts
+pnpm exec prettier --check src/config/codexTemplates.ts src/config/codexProviderPresets.ts src/components/providers/forms/hooks/useCodexConfigState.ts src/components/universal/UniversalProviderFormModal.tsx src/components/providers/forms/ProviderForm.tsx tests/config/codexDefaultConfig.test.ts
+cargo fmt --manifest-path src-tauri/Cargo.toml --check
+git diff --check
+pnpm dev
+```
+
+结果：
+
+- Codex 默认配置测试 2 个通过。
+- 前端格式检查通过。
+- Rust 格式检查通过。
+- Git 空白字符检查通过。
+- Tauri 开发版编译并启动成功。
+- 新建兔子线路页面显示 `model = "gpt-5.6-sol"`。
+- 新建配置显示 `requires_openai_auth = false` 和生图请求头。
+- 已存在的旧 Provider 仍保留原配置，未被自动覆盖。
+
+## 已知事项
+
+- 本机当前定价表尚未包含 `gpt-5.6-sol`，运行日志会提示未找到定价信息，相关费用暂按 0 记录。
+- 该提示不影响 Provider 配置生成、模型路由或 Codex 生图工具启用。
+- 真实图片输出仍依赖有效 API Key、第三方线路可用性以及上游生图能力。

--- a/qa/2026-07-16-Codex第三方生图默认配置-人工测试文档.md
+++ b/qa/2026-07-16-Codex第三方生图默认配置-人工测试文档.md
@@ -1,0 +1,130 @@
+# 2026-07-16 Codex 第三方生图默认配置人工测试文档
+
+## 测试范围
+
+- 新建 Codex Provider 默认模型为 `gpt-5.6-sol`。
+- 新建第三方 Provider 默认关闭 OpenAI 官方认证要求。
+- 新建第三方 Provider 默认包含 Codex 生图启用请求头。
+- 兔子线路、Codex 订阅、GACCode、自定义配置和通用 Provider 入口保持一致。
+- 已存在 Provider 不被默认模板更新强制覆盖。
+- API Key 继续通过 `env_key` 管理，不写入 `config.toml`。
+
+## 验收标准
+
+新建第三方 Codex Provider 的配置至少包含：
+
+```toml
+model = "gpt-5.6-sol"
+requires_openai_auth = false
+http_headers = { "x-openai-actor-authorization" = "http://coding.tu-zi.com" }
+```
+
+如果编辑器把请求头格式化成以下结构，也视为通过：
+
+```toml
+[model_providers.<provider_id>.http_headers]
+x-openai-actor-authorization = "http://coding.tu-zi.com"
+```
+
+## 已执行自动验证
+
+### 1. 默认模板测试
+
+执行：
+
+```bash
+pnpm vitest run tests/config/codexDefaultConfig.test.ts
+```
+
+结果：
+
+- 测试文件 1 个通过。
+- 测试用例 2 个通过。
+- 自定义模板包含 `gpt-5.6-sol`、`requires_openai_auth = false` 和生图请求头。
+- 第三方配置生成函数的默认输出包含同样配置。
+
+### 2. 格式与静态检查
+
+执行：
+
+```bash
+pnpm exec prettier --check src/config/codexTemplates.ts src/config/codexProviderPresets.ts src/components/providers/forms/hooks/useCodexConfigState.ts src/components/universal/UniversalProviderFormModal.tsx src/components/providers/forms/ProviderForm.tsx tests/config/codexDefaultConfig.test.ts
+cargo fmt --manifest-path src-tauri/Cargo.toml --check
+git diff --check
+```
+
+结果：全部通过。
+
+### 3. 开发版启动验证
+
+执行：
+
+```bash
+pnpm dev
+```
+
+结果：
+
+- Tauri 开发版编译成功并正常启动。
+- 未使用已安装的旧版应用进行判断。
+
+## 已执行页面验证
+
+### 场景 1：新建兔子线路
+
+步骤：
+
+1. 进入 Codex 页签。
+2. 打开“添加供应商”。
+3. 选择“兔子线路”。
+4. 展开 `config.toml (TOML)`。
+
+实际结果：
+
+- 模型字段显示 `gpt-5.6-sol`。
+- Provider section 显示 `requires_openai_auth = false`。
+- 请求头显示为 `[model_providers.tuzi.http_headers]` 表结构。
+- `x-openai-actor-authorization` 的值为 `http://coding.tu-zi.com`。
+- API Key 通过 `TUZI_CODEX_API_KEY` 环境变量引用。
+
+结论：通过。
+
+### 场景 2：已有 Provider 兼容性
+
+步骤：
+
+1. 打开一个修改前已存在的 Codex Provider。
+2. 展开其 `config.toml (TOML)`。
+
+实际结果：
+
+- 已有 Provider 仍保留原来的 `gpt-5.5`。
+- 没有因启动新版应用而被强制改写。
+
+结论：通过，符合“只更新新默认配置”的兼容设计。
+
+## 待执行真实链路验证
+
+以下步骤需要有效的第三方 API Key，并会真实调用上游服务：
+
+1. 新建兔子线路或 Codex 订阅 Provider。
+2. 填入有效 API Key 并保存。
+3. 切换到该 Provider，确认 `~/.codex/config.toml` 写入新配置。
+4. 完全退出并重新启动 Codex App。
+5. 发起“生成一张测试图片”的任务。
+6. 确认 Codex 能调用 `image_gen`，图片成功保存并在 App 中显示。
+
+通过标准：
+
+- Codex 不再提示第三方 Provider 未启用生图工具。
+- 生图请求到达上游线路。
+- 返回图片能够在 Codex App 中正常展示。
+
+## 回归关注
+
+- 不应覆盖用户已有 Provider 的模型、Endpoint、Key 或自定义请求头。
+- 不应给 OpenAI Official Provider 强制设置 `requires_openai_auth = false`。
+- 不应把真实 API Key 写入 `config.toml` 或请求头。
+- TOML 单行 `http_headers` 和序列化后的子表格式应保持语义一致。
+- 深链导入、通用 Provider 和自动识别 live Key 生成的配置也应包含生图请求头。
+- `gpt-5.6-sol` 当前缺少本地定价数据时，费用统计可能显示为 0；该现象不应影响模型调用。

--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -302,7 +302,7 @@ pub fn switch_codex_profile(
     let new_format = is_new_profile_format();
 
     if config_text.trim().is_empty() {
-        let m = model.unwrap_or("gpt-5.5");
+        let m = model.unwrap_or("gpt-5.6-sol");
         let e = model_reasoning_effort.unwrap_or("high");
         let mut s = format!("model_provider = \"{route_id}\"\nmodel = \"{m}\"\nmodel_reasoning_effort = \"{e}\"\ndisable_response_storage = true\n");
         if !new_format {
@@ -346,7 +346,7 @@ pub fn save_route_to_config(
     let new_format = is_new_profile_format();
 
     let mut provider_section = format!(
-        "[model_providers.{route_id}]\nname = \"{route_id}\"\nbase_url = \"{base_url}\"\nwire_api = \"responses\"\nrequires_openai_auth = true\n"
+        "[model_providers.{route_id}]\nname = \"{route_id}\"\nbase_url = \"{base_url}\"\nwire_api = \"responses\"\nrequires_openai_auth = false\nhttp_headers = {{ \"x-openai-actor-authorization\" = \"http://coding.tu-zi.com\" }}\n"
     );
     if !env_key.trim().is_empty() {
         provider_section.push_str(&format!("env_key = \"{env_key}\"\n"));

--- a/src-tauri/src/commands/provider.rs
+++ b/src-tauri/src/commands/provider.rs
@@ -796,7 +796,7 @@ pub fn sync_codex_live_api_key(state: State<'_, AppState>) -> Result<(), String>
         let card_name = card_id.clone();
 
         let config_toml = format!(
-            "model_provider = \"{card_id}\"\nmodel = \"gpt-5.5\"\nmodel_reasoning_effort = \"high\"\ndisable_response_storage = true\n\n[model_providers.{card_id}]\nname = \"{card_id}\"\nbase_url = \"{detected_url}\"\nwire_api = \"responses\"\nrequires_openai_auth = true\n"
+            "model_provider = \"{card_id}\"\nmodel = \"gpt-5.6-sol\"\nmodel_reasoning_effort = \"high\"\ndisable_response_storage = true\n\n[model_providers.{card_id}]\nname = \"{card_id}\"\nbase_url = \"{detected_url}\"\nwire_api = \"responses\"\nrequires_openai_auth = false\nhttp_headers = {{ \"x-openai-actor-authorization\" = \"http://coding.tu-zi.com\" }}\n"
         );
 
         let new_provider = crate::provider::Provider::with_id(

--- a/src-tauri/src/database/dao/providers.rs
+++ b/src-tauri/src/database/dao/providers.rs
@@ -32,7 +32,7 @@ fn build_codex_official_provider(
         _ => id,
     };
     let config = format!(
-        "model_provider = \"{route_id}\"\nmodel = \"{model}\"\nmodel_reasoning_effort = \"high\"\ndisable_response_storage = true\n\n[model_providers.{route_id}]\nname = \"{route_id}\"\nbase_url = \"{base_url}\"\nenv_key = \"{env_key}\"\nwire_api = \"responses\"\nrequires_openai_auth = true\n"
+        "model_provider = \"{route_id}\"\nmodel = \"{model}\"\nmodel_reasoning_effort = \"high\"\ndisable_response_storage = true\n\n[model_providers.{route_id}]\nname = \"{route_id}\"\nbase_url = \"{base_url}\"\nenv_key = \"{env_key}\"\nwire_api = \"responses\"\nrequires_openai_auth = false\nhttp_headers = {{ \"x-openai-actor-authorization\" = \"http://coding.tu-zi.com\" }}\n"
     );
     let mut provider = Provider::with_id(
         id.to_string(),

--- a/src-tauri/src/database/dao/providers_seed.rs
+++ b/src-tauri/src/database/dao/providers_seed.rs
@@ -22,7 +22,7 @@ pub(crate) const CODEX_OFFICIAL_PROVIDER_IDS: &[(&str, &str, &str, &str, &str, &
         "https://api.tu-zi.com",
         "https://api.tu-zi.com/v1",
         "TUZI_CODEX_API_KEY",
-        "gpt-5.5",
+        "gpt-5.6-sol",
     ),
     (
         "coding",
@@ -30,7 +30,7 @@ pub(crate) const CODEX_OFFICIAL_PROVIDER_IDS: &[(&str, &str, &str, &str, &str, &
         "https://store.tu-zi.com/cat/11",
         "https://api.tu-zi.com/coding",
         "CODING_CODEX_API_KEY",
-        "gpt-5.5",
+        "gpt-5.6-sol",
     ),
     (
         "gaccode",
@@ -38,7 +38,7 @@ pub(crate) const CODEX_OFFICIAL_PROVIDER_IDS: &[(&str, &str, &str, &str, &str, &
         "https://store.tu-zi.com/cat/1",
         "https://gaccode.com/codex/v1",
         "GAC_CODEX_API_KEY",
-        "gpt-5.5",
+        "gpt-5.6-sol",
     ),
 ];
 

--- a/src-tauri/src/deeplink/provider.rs
+++ b/src-tauri/src/deeplink/provider.rs
@@ -342,7 +342,8 @@ disable_response_storage = true
 name = "{clean_provider_name}"
 base_url = "{endpoint}"
 wire_api = "responses"
-requires_openai_auth = true
+requires_openai_auth = false
+http_headers = {{ "x-openai-actor-authorization" = "http://coding.tu-zi.com" }}
 "#
     );
 

--- a/src-tauri/src/provider.rs
+++ b/src-tauri/src/provider.rs
@@ -612,7 +612,8 @@ disable_response_storage = true
 name = "NewAPI"
 base_url = "{codex_base_url}"
 wire_api = "responses"
-requires_openai_auth = true"#
+requires_openai_auth = false
+http_headers = {{ "x-openai-actor-authorization" = "http://coding.tu-zi.com" }}"#
         );
 
         let settings_config = serde_json::json!({

--- a/src/components/providers/forms/ProviderForm.tsx
+++ b/src/components/providers/forms/ProviderForm.tsx
@@ -1311,7 +1311,9 @@ function ProviderFormFull({
             envKey: resolvedCodexEnvKey,
             apiKey: codexApiKey || "",
             model:
-              normalizedCatalogModels[0]?.model || codexModelName || "gpt-5.5",
+              normalizedCatalogModels[0]?.model ||
+              codexModelName ||
+              "gpt-5.6-sol",
             modelReasoningEffort: "high",
           });
         }
@@ -1753,7 +1755,7 @@ function ProviderFormFull({
             newRouteId,
             preset.endpointCandidates?.[0] || "",
             envKey,
-            "gpt-5.5",
+            "gpt-5.6-sol",
           );
         }
       }

--- a/src/components/providers/forms/hooks/useCodexConfigState.ts
+++ b/src/components/providers/forms/hooks/useCodexConfigState.ts
@@ -50,7 +50,7 @@ function migrateLegacyConfig(configStr: string): string {
   const effortMatch = result.match(
     /^\s*model_reasoning_effort\s*=\s*"([^"]+)"/m,
   );
-  const model = modelMatch?.[1] || "gpt-5.5";
+  const model = modelMatch?.[1] || "gpt-5.6-sol";
   const effort = effortMatch?.[1] || "high";
 
   // Build new format
@@ -100,7 +100,10 @@ function migrateLegacyConfig(configStr: string): string {
     output.push(`name = "${providerName}"`);
     output.push(`env_key = "OPENAI_API_KEY"`);
     output.push(`wire_api = "responses"`);
-    output.push(`requires_openai_auth = true`);
+    output.push(`requires_openai_auth = false`);
+    output.push(
+      `http_headers = { "x-openai-actor-authorization" = "http://coding.tu-zi.com" }`,
+    );
   }
 
   return output.join("\n");

--- a/src/components/universal/UniversalProviderFormModal.tsx
+++ b/src/components/universal/UniversalProviderFormModal.tsx
@@ -145,7 +145,7 @@ export function UniversalProviderFormModal({
   // 计算 Codex 配置 JSON 预览
   const codexConfigJson = useMemo(() => {
     if (!codexEnabled) return null;
-    const model = models.codex?.model || "gpt-5.4";
+    const model = models.codex?.model || "gpt-5.6-sol";
     const reasoningEffort = models.codex?.reasoningEffort || "high";
     // 确保 base_url 以 /v1 结尾（Codex 使用 OpenAI 兼容 API）
     const codexBaseUrl = baseUrl.endsWith("/v1")
@@ -160,7 +160,8 @@ disable_response_storage = true
 name = "NewAPI"
 base_url = "${codexBaseUrl}"
 wire_api = "responses"
-requires_openai_auth = true`;
+requires_openai_auth = false
+http_headers = { "x-openai-actor-authorization" = "http://coding.tu-zi.com" }`;
     return {
       auth: {
         OPENAI_API_KEY: apiKey,
@@ -591,7 +592,7 @@ requires_openai_auth = true`;
                     onChange={(e) =>
                       updateModel("codex", "model", e.target.value)
                     }
-                    placeholder="gpt-5.4"
+                    placeholder="gpt-5.6-sol"
                   />
                 </div>
                 <div className="space-y-1">

--- a/src/config/codexProviderPresets.ts
+++ b/src/config/codexProviderPresets.ts
@@ -43,7 +43,7 @@ export function generateThirdPartyConfig(
   providerName: string,
   baseUrl: string,
   envKey: string,
-  modelName = "gpt-5.5",
+  modelName = "gpt-5.6-sol",
 ): string {
   const cleanProviderName =
     providerName
@@ -61,7 +61,8 @@ name = "${cleanProviderName}"
 base_url = "${baseUrl}"
 env_key = "${envKey}"
 wire_api = "responses"
-requires_openai_auth = true`;
+requires_openai_auth = false
+http_headers = { "x-openai-actor-authorization" = "http://coding.tu-zi.com" }`;
 }
 
 export const codexProviderPresets: CodexProviderPreset[] = [
@@ -74,7 +75,7 @@ export const codexProviderPresets: CodexProviderPreset[] = [
       "tuzi",
       "https://api.tu-zi.com/v1",
       "TUZI_CODEX_API_KEY",
-      "gpt-5.5",
+      "gpt-5.6-sol",
     ),
     envKey: "TUZI_CODEX_API_KEY",
     category: "aggregator",
@@ -91,7 +92,7 @@ export const codexProviderPresets: CodexProviderPreset[] = [
       "codex",
       "https://api.tu-zi.com/coding",
       "CODING_CODEX_API_KEY",
-      "gpt-5.5",
+      "gpt-5.6-sol",
     ),
     envKey: "CODING_CODEX_API_KEY",
     category: "aggregator",
@@ -113,7 +114,7 @@ export const codexProviderPresets: CodexProviderPreset[] = [
       "gac",
       "https://gaccode.com/codex/v1",
       "GAC_CODEX_API_KEY",
-      "gpt-5.5",
+      "gpt-5.6-sol",
     ),
     envKey: "GAC_CODEX_API_KEY",
     category: "aggregator",

--- a/src/config/codexTemplates.ts
+++ b/src/config/codexTemplates.ts
@@ -10,7 +10,7 @@ export interface CodexTemplate {
 
 export function getCodexCustomTemplate(): CodexTemplate {
   const config = `model_provider = "tuziswitch"
-model = "gpt-5.5"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 disable_response_storage = true
 
@@ -19,7 +19,8 @@ name = "tuziswitch"
 base_url = "https://your-api-endpoint.com/v1"
 env_key = "CUSTOM_CODEX_API_KEY"
 wire_api = "responses"
-requires_openai_auth = true`;
+requires_openai_auth = false
+http_headers = { "x-openai-actor-authorization" = "http://coding.tu-zi.com" }`;
 
   return {
     auth: {},

--- a/tests/config/codexDefaultConfig.test.ts
+++ b/tests/config/codexDefaultConfig.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { generateThirdPartyConfig } from "@/config/codexProviderPresets";
+import { getCodexCustomTemplate } from "@/config/codexTemplates";
+
+const IMAGE_GENERATION_HEADER =
+  'http_headers = { "x-openai-actor-authorization" = "http://coding.tu-zi.com" }';
+
+describe("Codex default config", () => {
+  it("enables local image generation for the custom provider template", () => {
+    const template = getCodexCustomTemplate();
+
+    expect(template.config).toContain('model = "gpt-5.6-sol"');
+    expect(template.config).toContain("requires_openai_auth = false");
+    expect(template.config).toContain(IMAGE_GENERATION_HEADER);
+  });
+
+  it("enables local image generation for third-party provider configs", () => {
+    const config = generateThirdPartyConfig(
+      "tuzi",
+      "https://api.tu-zi.com/v1",
+      "TUZI_CODEX_API_KEY",
+    );
+
+    expect(config).toContain('model = "gpt-5.6-sol"');
+    expect(config).toContain("requires_openai_auth = false");
+    expect(config).toContain(IMAGE_GENERATION_HEADER);
+  });
+});


### PR DESCRIPTION
## 问题描述

新版 Codex App 使用第三方 Provider 且 `requires_openai_auth = false` 时，如果缺少非空的 `x-openai-actor-authorization` 请求头，本地 `image_gen` 工具不会启用，用户需要手动修改 `config.toml`。兔子相关 Codex 默认模型也仍停留在旧版本。

## 修复思路

- 第三方 Codex 默认配置统一写入 `requires_openai_auth = false`。
- 默认添加 `x-openai-actor-authorization = "http://coding.tu-zi.com"`，启用 Codex 生图工具。
- 兔子线路、Codex 订阅、GACCode 及兜底模型更新为 `gpt-5.6-sol`。
- 保留已有 Provider 配置，不执行强制覆盖。
- API Key 继续通过 `env_key` 管理，不写入 TOML 或请求头。

## 更新代码架构

- 同步前端自定义模板、供应商预设、通用供应商和旧配置迁移入口。
- 同步 Rust 种子数据、路由保存、深链导入、通用 Provider 转换和 live Key 自动生成入口。
- 新增 Codex 默认配置单元测试。
- 新增交接文档与人工 QA 文档。

## 验证结果

- `pnpm vitest run tests/config/codexDefaultConfig.test.ts`：2 项通过。
- Prettier 检查通过。
- `cargo fmt --check` 通过。
- `cargo check` 通过，仅有既有的 `get_codex_version` 未使用警告。
- `git diff --check` 通过。
- Tauri 开发版启动成功，新建兔子线路页面显示 `gpt-5.6-sol` 与生图请求头。
- 已有旧 Provider 未被自动覆盖。

## 说明

本 PR 直接基于最新 `develop` 创建，不依赖未合并的 #35。真实图片输出仍需有效第三方 API Key 与可用上游生图服务。