### PR TITLE
fix: 保留 Codex 配置编辑内容

### DIFF
--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -9,6 +9,7 @@ use crate::codex_config;
 use crate::config::{self, get_claude_settings_path, ConfigStatus};
 use crate::settings;
 use crate::store::AppState;
+use toml_edit::{DocumentMut, Item};
 
 #[tauri::command]
 pub async fn get_claude_config_status() -> Result<ConfigStatus, String> {
@@ -453,6 +454,38 @@ fn codex_active_provider_field(config_text: &str, field: &str) -> Option<String>
         .map(ToString::to_string)
 }
 
+fn merge_codex_config_edits(existing: &str, edited: &str) -> Result<String, String> {
+    fn merge_item(target: &mut Item, source: &Item) {
+        if let (Some(target_table), Some(source_table)) =
+            (target.as_table_like_mut(), source.as_table_like())
+        {
+            for (key, source_item) in source_table.iter() {
+                match target_table.get_mut(key) {
+                    Some(target_item) => merge_item(target_item, source_item),
+                    None => {
+                        target_table.insert(key, source_item.clone());
+                    }
+                }
+            }
+        } else {
+            *target = source.clone();
+        }
+    }
+
+    let mut target = if existing.trim().is_empty() {
+        DocumentMut::new()
+    } else {
+        existing
+            .parse::<DocumentMut>()
+            .map_err(|e| format!("Invalid existing Codex config.toml: {e}"))?
+    };
+    let source = edited
+        .parse::<DocumentMut>()
+        .map_err(|e| format!("Invalid edited Codex config.toml: {e}"))?;
+    merge_item(target.as_item_mut(), source.as_item());
+    Ok(target.to_string())
+}
+
 #[derive(Debug, Clone, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SaveCodexRouteResult {
@@ -550,8 +583,13 @@ fn save_codex_route_inner(
 
     // Write route section to config.toml
     let existing = codex_config::read_codex_config_text().map_err(|e| e.to_string())?;
+    let existing_with_edits = if source_config.is_some() {
+        merge_codex_config_edits(&existing, normalized_config)?
+    } else {
+        existing
+    };
     let updated = codex_config::save_route_to_config_with_provider_config(
-        &existing,
+        &existing_with_edits,
         &normalized_route_id,
         &normalized_base_url,
         &normalized_env_key,

--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -472,15 +472,33 @@ fn save_codex_route_inner(
     modelReasoningEffort: String,
     profileName: Option<String>,
     providerId: Option<String>,
+    configText: Option<String>,
 ) -> Result<SaveCodexRouteResult, String> {
-    let route_draft = codex_config::save_route_to_config(
-        "",
-        &routeId,
-        &baseUrl,
-        &envKey,
-        &model,
-        &modelReasoningEffort,
-    )
+    let source_config = configText
+        .as_deref()
+        .map(str::trim)
+        .filter(|config| !config.is_empty());
+
+    let route_draft = if let Some(config) = source_config {
+        codex_config::save_route_to_config_with_provider_config(
+            config,
+            &routeId,
+            &baseUrl,
+            &envKey,
+            &model,
+            &modelReasoningEffort,
+            Some(config),
+        )
+    } else {
+        codex_config::save_route_to_config(
+            "",
+            &routeId,
+            &baseUrl,
+            &envKey,
+            &model,
+            &modelReasoningEffort,
+        )
+    }
     .map_err(|e| e.to_string())?;
     let route_draft = codex_config::switch_codex_profile(
         &route_draft,
@@ -579,6 +597,7 @@ pub fn save_codex_route(
     modelReasoningEffort: String,
     profileName: Option<String>,
     providerId: Option<String>,
+    configText: Option<String>,
 ) -> Result<SaveCodexRouteResult, String> {
     save_codex_route_inner(
         state.inner(),
@@ -590,6 +609,7 @@ pub fn save_codex_route(
         modelReasoningEffort,
         profileName,
         providerId,
+        configText,
     )
 }
 
@@ -605,6 +625,7 @@ pub fn save_codex_route_test_hook(
     modelReasoningEffort: String,
     profileName: Option<String>,
     providerId: Option<String>,
+    configText: Option<String>,
 ) -> Result<SaveCodexRouteResult, String> {
     save_codex_route_inner(
         state,
@@ -616,5 +637,6 @@ pub fn save_codex_route_test_hook(
         modelReasoningEffort,
         profileName,
         providerId,
+        configText,
     )
 }

--- a/src-tauri/tests/provider_commands.rs
+++ b/src-tauri/tests/provider_commands.rs
@@ -804,6 +804,23 @@ request_max_retries = 7
 trust_level = "trusted"
 "#;
 
+    let existing_live_config = r#"model_provider = "existing"
+model = "gpt-5.5"
+approval_policy = "on-request"
+
+[model_providers.existing]
+name = "existing"
+base_url = "https://existing.example/v1"
+env_key = "EXISTING_CODEX_API_KEY"
+wire_api = "responses"
+requires_openai_auth = false
+
+[projects."/tmp/work"]
+trust_level = "untrusted"
+"#;
+    write_codex_live_atomic(&json!({}), Some(existing_live_config))
+        .expect("seed existing live config");
+
     let state = create_test_state().expect("create test state");
 
     let saved_route = save_codex_route_test_hook(
@@ -837,6 +854,39 @@ trust_level = "trusted"
             .config
             .contains("base_url = \"https://api.tu-zi.com/v1\""),
         "managed route fields should still be updated"
+    );
+
+    let live_config =
+        std::fs::read_to_string(get_codex_config_path()).expect("read updated live config");
+    assert!(
+        live_config.contains("approval_policy = \"never\""),
+        "live config should preserve user-edited top-level fields"
+    );
+    assert!(
+        live_config.contains("[projects.\"/tmp/work\"]"),
+        "live config should preserve user-edited unrelated sections"
+    );
+    assert!(
+        live_config.contains("trust_level = \"trusted\""),
+        "live config should apply edited values over existing values"
+    );
+    assert!(
+        live_config.contains("[model_providers.existing]"),
+        "live config should preserve other registered provider routes"
+    );
+
+    let home = std::env::var("HOME").expect("HOME should be set by ensure_test_home");
+    let profile_path = std::path::Path::new(&home)
+        .join(".codex")
+        .join("兔子线路-我的配置.config.toml");
+    let profile_config = std::fs::read_to_string(profile_path).expect("read saved profile config");
+    assert!(
+        profile_config.contains("approval_policy = \"never\""),
+        "profile config should preserve user-edited top-level fields"
+    );
+    assert!(
+        profile_config.contains("[projects.\"/tmp/work\"]"),
+        "profile config should preserve user-edited unrelated sections"
     );
 }
 

--- a/src-tauri/tests/provider_commands.rs
+++ b/src-tauri/tests/provider_commands.rs
@@ -748,6 +748,7 @@ requires_openai_auth = false
         "high".to_string(),
         Some("兔子线路-我的配置".to_string()),
         None,
+        None,
     )
     .expect("save codex route");
     assert_eq!(saved_route.route_id, "provider-tuzi01");
@@ -777,6 +778,65 @@ requires_openai_auth = false
     assert!(
         zshrc.contains("export TUZI01_CODEX_API_KEY='sk-test'"),
         "save_codex_route should create the matching managed env key"
+    );
+}
+
+#[test]
+fn save_codex_route_preserves_edited_codex_config_text() {
+    let _guard = test_mutex().lock().expect("acquire test mutex");
+    reset_test_fs();
+    let _home = ensure_test_home();
+
+    let edited_config = r#"model_provider = "tuzi"
+model = "gpt-5.4"
+model_reasoning_effort = "medium"
+approval_policy = "never"
+
+[model_providers.tuzi]
+name = "tuzi"
+base_url = "https://old.example/v1"
+env_key = "TUZI_CODEX_API_KEY"
+wire_api = "responses"
+requires_openai_auth = false
+request_max_retries = 7
+
+[projects."/tmp/work"]
+trust_level = "trusted"
+"#;
+
+    let state = create_test_state().expect("create test state");
+
+    let saved_route = save_codex_route_test_hook(
+        &state,
+        "tuzi".to_string(),
+        "https://api.tu-zi.com/v1".to_string(),
+        "TUZI_CODEX_API_KEY".to_string(),
+        "sk-test".to_string(),
+        "gpt-5.5".to_string(),
+        "high".to_string(),
+        Some("兔子线路-我的配置".to_string()),
+        None,
+        Some(edited_config.to_string()),
+    )
+    .expect("save codex route");
+
+    assert!(
+        saved_route.config.contains("approval_policy = \"never\""),
+        "returned config should preserve user-edited top-level fields"
+    );
+    assert!(
+        saved_route.config.contains("request_max_retries = 7"),
+        "returned config should preserve user-edited provider fields"
+    );
+    assert!(
+        saved_route.config.contains("[projects.\"/tmp/work\"]"),
+        "returned config should preserve unrelated user sections"
+    );
+    assert!(
+        saved_route
+            .config
+            .contains("base_url = \"https://api.tu-zi.com/v1\""),
+        "managed route fields should still be updated"
     );
 }
 

--- a/src/components/providers/forms/ProviderForm.tsx
+++ b/src/components/providers/forms/ProviderForm.tsx
@@ -1613,6 +1613,7 @@ function ProviderFormFull({
               modelReasoningEffort: "high",
               profileName: values.name.trim(),
               providerId,
+              configText: normalizedCodexConfig,
             },
           );
           if (savedRoute?.config) {


### PR DESCRIPTION
## Summary
- pass the current Codex config.toml editor text into save_codex_route
- preserve user-edited TOML fields and sections while still normalizing managed route/base_url/env_key fields
- add a regression test for edited Codex config persistence

## Verification
- CI=true pnpm exec tsc --noEmit --pretty false
- CI=true pnpm run build:renderer
- cargo test --manifest-path src-tauri/Cargo.toml --features test-hooks save_codex_route --test provider_commands
- cargo check --manifest-path src-tauri/Cargo.toml --features test-hooks