### PR TITLE
修复：持久化 Codex 供应商凭据以支持桌面端启动

### DIFF
--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -343,6 +343,15 @@ fn read_codex_env_file() -> HashMap<String, String> {
         .collect()
 }
 
+fn read_codex_env_key_file(env_key: &str) -> Result<Option<String>, AppError> {
+    if !is_valid_env_key_name(env_key) {
+        return Ok(None);
+    }
+    Ok(read_codex_env_file()
+        .remove(env_key)
+        .filter(|value| !value.trim().is_empty()))
+}
+
 fn write_codex_env_file(env_map: &HashMap<String, String>) -> Result<(), AppError> {
     let path = get_codex_env_file_path();
     if env_map.is_empty() {
@@ -375,6 +384,18 @@ fn write_codex_env_file(env_map: &HashMap<String, String>) -> Result<(), AppErro
     Ok(())
 }
 
+fn write_codex_env_key_file(env_key: &str, value: &str) -> Result<(), AppError> {
+    validate_env_key_name(env_key)?;
+    if value.trim().is_empty() || value.contains(['\r', '\n']) {
+        return Err(AppError::InvalidInput(
+            "Codex API Key 为空或包含换行符".to_string(),
+        ));
+    }
+    let mut codex_env = read_codex_env_file();
+    codex_env.insert(env_key.to_string(), value.to_string());
+    write_codex_env_file(&codex_env)
+}
+
 pub fn read_managed_env_block() -> HashMap<String, String> {
     if cfg!(target_os = "windows") {
         return read_windows_env_keys();
@@ -400,7 +421,10 @@ pub fn read_managed_env_key(env_key: &str) -> Option<String> {
     if !is_valid_env_key_name(env_key) {
         return None;
     }
-    if let Some(value) = read_codex_env_file().remove(env_key) {
+    if let Some(value) = read_codex_env_file()
+        .remove(env_key)
+        .filter(|value| !value.trim().is_empty())
+    {
         return Some(value);
     }
     if cfg!(target_os = "windows") {
@@ -435,6 +459,43 @@ pub fn read_managed_env_key(env_key: &str) -> Option<String> {
         }
     }
     None
+}
+
+fn missing_codex_env_key_error(env_key: &str) -> AppError {
+    AppError::localized(
+        "codex.provider_env_key_missing",
+        format!(
+            "Codex 供应商需要环境变量 {env_key}，但未找到对应 API Key。请重新填写并保存该供应商后再启用；当前可用配置未被覆盖。"
+        ),
+        format!(
+            "The Codex provider requires environment variable {env_key}, but its API key is missing. Re-enter and save the provider before enabling it; the current working configuration was not overwritten."
+        ),
+    )
+}
+
+/// Ensure an env-backed provider credential is available to GUI-launched Codex.
+/// Shell startup files are a migration source only; ~/.codex/.env is the
+/// persistent source that desktop and IDE processes can load after a reboot.
+pub fn ensure_codex_provider_env_ready(config_text: &str) -> Result<(), AppError> {
+    let Some(env_key) = extract_codex_env_key(config_text) else {
+        return Ok(());
+    };
+    validate_env_key_name(&env_key)?;
+
+    if read_codex_env_key_file(&env_key)?.is_some() {
+        return Ok(());
+    }
+
+    let Some(value) = read_managed_env_key(&env_key) else {
+        return Err(missing_codex_env_key_error(&env_key));
+    };
+    write_codex_env_key_file(&env_key, &value)?;
+
+    if read_codex_env_key_file(&env_key)?.is_some() {
+        Ok(())
+    } else {
+        Err(missing_codex_env_key_error(&env_key))
+    }
 }
 
 pub fn write_managed_env_key(env_key: &str, value: &str) -> Result<(), AppError> {
@@ -1615,7 +1676,7 @@ fn codex_active_provider_table<'a>(
         .and_then(|item| item.as_table())
 }
 
-fn extract_codex_env_key(config_text: &str) -> Option<String> {
+pub(crate) fn extract_codex_env_key(config_text: &str) -> Option<String> {
     let doc = config_text.parse::<DocumentMut>().ok()?;
     let provider_id = active_codex_model_provider_id(&doc)?;
     codex_active_provider_table(&doc, &provider_id)
@@ -1725,6 +1786,7 @@ pub fn prepare_codex_provider_live_config(
     auth: &Value,
     config_text: &str,
 ) -> Result<String, AppError> {
+    ensure_codex_provider_env_ready(config_text)?;
     prepare_codex_provider_live_config_with_env_reader(auth, config_text, read_managed_env_key)
 }
 
@@ -1903,9 +1965,17 @@ fn prepare_codex_provider_live_config_with_env_reader(
     config_text: &str,
     read_env_key: impl Fn(&str) -> Option<String>,
 ) -> Result<String, AppError> {
-    let _ = extract_codex_auth_api_key(auth)
-        .or_else(|| extract_codex_env_key(config_text).and_then(|env_key| read_env_key(&env_key)))
-        .or_else(|| extract_codex_experimental_bearer_token(config_text));
+    if let Some(env_key) = extract_codex_env_key(config_text) {
+        if read_env_key(&env_key)
+            .filter(|value| !value.trim().is_empty())
+            .is_none()
+        {
+            return Err(missing_codex_env_key_error(&env_key));
+        }
+    } else {
+        let _ = extract_codex_auth_api_key(auth)
+            .or_else(|| extract_codex_experimental_bearer_token(config_text));
+    }
 
     remove_codex_live_only_provider_fields(config_text)
 }
@@ -3115,6 +3185,89 @@ mod tests {
             read_managed_env_key("TUZI_TEST_CODEX_API_KEY").as_deref(),
             Some("sk-dotenv")
         );
+
+        match old_test_home {
+            Some(value) => std::env::set_var("CC_SWITCH_TEST_HOME", value),
+            None => std::env::remove_var("CC_SWITCH_TEST_HOME"),
+        }
+    }
+
+    #[test]
+    fn ensure_provider_env_ready_accepts_existing_codex_dotenv_key() {
+        let _guard = TEST_ENV_LOCK.lock().expect("lock test env");
+        let temp = tempfile::tempdir().expect("temp home");
+        let old_test_home = std::env::var_os("CC_SWITCH_TEST_HOME");
+        std::env::set_var("CC_SWITCH_TEST_HOME", temp.path());
+        fs::create_dir_all(temp.path().join(".codex")).expect("create Codex dir");
+        fs::write(
+            temp.path().join(".codex").join(".env"),
+            "READY_CODEX_API_KEY=stored-key\n",
+        )
+        .expect("seed Codex dotenv");
+
+        let config = r#"model_provider = "custom"
+[model_providers.custom]
+env_key = "READY_CODEX_API_KEY"
+"#;
+        ensure_codex_provider_env_ready(config).expect("existing key should be accepted");
+        assert_eq!(
+            read_codex_env_key_file("READY_CODEX_API_KEY").expect("read key"),
+            Some("stored-key".to_string())
+        );
+
+        match old_test_home {
+            Some(value) => std::env::set_var("CC_SWITCH_TEST_HOME", value),
+            None => std::env::remove_var("CC_SWITCH_TEST_HOME"),
+        }
+    }
+
+    #[test]
+    fn ensure_provider_env_ready_migrates_shell_key_to_codex_dotenv() {
+        let _guard = TEST_ENV_LOCK.lock().expect("lock test env");
+        let temp = tempfile::tempdir().expect("temp home");
+        let old_test_home = std::env::var_os("CC_SWITCH_TEST_HOME");
+        std::env::set_var("CC_SWITCH_TEST_HOME", temp.path());
+        fs::write(
+            temp.path().join(".zshrc"),
+            "# Codex\nexport MIGRATE_CODEX_API_KEY='shell-key'\n",
+        )
+        .expect("seed shell rc");
+
+        let config = r#"model_provider = "custom"
+[model_providers.custom]
+env_key = "MIGRATE_CODEX_API_KEY"
+"#;
+        ensure_codex_provider_env_ready(config).expect("shell key should migrate");
+        assert_eq!(
+            read_codex_env_key_file("MIGRATE_CODEX_API_KEY").expect("read migrated key"),
+            Some("shell-key".to_string())
+        );
+
+        match old_test_home {
+            Some(value) => std::env::set_var("CC_SWITCH_TEST_HOME", value),
+            None => std::env::remove_var("CC_SWITCH_TEST_HOME"),
+        }
+    }
+
+    #[test]
+    fn ensure_provider_env_ready_rejects_missing_or_blank_key_without_changing_dotenv() {
+        let _guard = TEST_ENV_LOCK.lock().expect("lock test env");
+        let temp = tempfile::tempdir().expect("temp home");
+        let old_test_home = std::env::var_os("CC_SWITCH_TEST_HOME");
+        std::env::set_var("CC_SWITCH_TEST_HOME", temp.path());
+        fs::create_dir_all(temp.path().join(".codex")).expect("create Codex dir");
+        let dotenv = temp.path().join(".codex").join(".env");
+        let original = "KEEP_CODEX_API_KEY=keep\nMISSING_CODEX_API_KEY=   \n";
+        fs::write(&dotenv, original).expect("seed Codex dotenv");
+
+        let config = r#"model_provider = "custom"
+[model_providers.custom]
+env_key = "MISSING_CODEX_API_KEY"
+"#;
+        let error = ensure_codex_provider_env_ready(config)
+            .expect_err("blank key should be treated as missing");
+        assert!(error.to_string().contains("MISSING_CODEX_API_KEY"));
+        assert_eq!(fs::read_to_string(&dotenv).expect("read dotenv"), original);
 
         match old_test_home {
             Some(value) => std::env::set_var("CC_SWITCH_TEST_HOME", value),

--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -581,6 +581,11 @@ fn save_codex_route_inner(
             .map_err(|e| e.to_string())?;
     }
 
+    // Validate the final route before touching config.toml or its profile. This
+    // keeps a failed save from replacing a working live route with one whose
+    // env-backed credential is unavailable to the desktop process.
+    codex_config::ensure_codex_provider_env_ready(normalized_config).map_err(|e| e.to_string())?;
+
     // Write route section to config.toml
     let existing = codex_config::read_codex_config_text().map_err(|e| e.to_string())?;
     let existing_with_edits = if source_config.is_some() {

--- a/src-tauri/src/deeplink/provider.rs
+++ b/src-tauri/src/deeplink/provider.rs
@@ -112,8 +112,50 @@ pub fn import_provider_from_deeplink(
 
     let provider_id = provider.id.clone();
 
+    // Codex credentials must be persisted under the final normalized env_key
+    // before ProviderService validates or writes this provider. Keep the old
+    // value so a later add failure can restore the credential store.
+    let codex_env_rollback = if matches!(app_type, AppType::Codex) {
+        crate::services::provider::normalize_codex_managed_provider_for_storage(
+            state.db.as_ref(),
+            &mut provider,
+            None,
+        )?;
+        let env_key = provider
+            .settings_config
+            .get("config")
+            .and_then(serde_json::Value::as_str)
+            .and_then(crate::codex_config::extract_codex_env_key)
+            .or_else(|| {
+                provider
+                    .settings_config
+                    .pointer("/env/envKey")
+                    .and_then(serde_json::Value::as_str)
+                    .map(str::to_string)
+            })
+            .ok_or_else(|| AppError::Config("Codex provider env_key is missing".to_string()))?;
+        let previous_value = crate::codex_config::read_managed_env_key(&env_key);
+        crate::codex_config::write_managed_env_key(&env_key, api_key)?;
+        Some((env_key, previous_value))
+    } else {
+        None
+    };
+
     // Use ProviderService to add the provider
-    ProviderService::add(state, app_type.clone(), provider, true)?;
+    if let Err(error) = ProviderService::add(state, app_type.clone(), provider, true) {
+        if let Some((env_key, previous_value)) = codex_env_rollback {
+            let rollback = match previous_value {
+                Some(value) => crate::codex_config::write_managed_env_key(&env_key, &value),
+                None => crate::codex_config::remove_managed_env_key(&env_key),
+            };
+            if let Err(rollback_error) = rollback {
+                log::error!(
+                    "Failed to roll back Codex env key after deep-link import error: {rollback_error}"
+                );
+            }
+        }
+        return Err(error);
+    }
 
     // Add extra endpoints as custom endpoints (skip first one as it's the primary)
     for ep in all_endpoints.iter().skip(1) {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -602,7 +602,28 @@ pub fn run() {
             }
 
             {
-                if crate::settings::unify_codex_session_history() {
+                let current_codex_credential_ready =
+                    match crate::services::provider::ensure_current_codex_provider_env_ready(
+                        &app_state,
+                    ) {
+                        Ok(true) => {
+                            log::info!(
+                                "✓ Current Codex provider credential is available to desktop processes"
+                            );
+                            true
+                        }
+                        Ok(false) => true,
+                        Err(e) => {
+                            log::warn!(
+                                "✗ Current Codex provider credential is unavailable; live config was not changed: {e}"
+                            );
+                            false
+                        }
+                    };
+
+                if current_codex_credential_ready
+                    && crate::settings::unify_codex_session_history()
+                {
                     if let Err(e) = crate::services::provider::reapply_current_codex_live(&app_state)
                     {
                         log::warn!("✗ Failed to reapply Codex unified live config on startup: {e}");

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -42,6 +42,32 @@ use live::{
 };
 use usage::validate_usage_script;
 
+/// Make the credential for the selected Codex provider available to processes
+/// launched outside a login shell. This only migrates the key to Codex's
+/// persistent `.env`; it never rewrites the live provider configuration.
+pub fn ensure_current_codex_provider_env_ready(state: &AppState) -> Result<bool, AppError> {
+    let current_id = ProviderService::current(state, AppType::Codex)?;
+    if current_id.is_empty() {
+        return Ok(false);
+    }
+    let Some(provider) = state
+        .db
+        .get_provider_by_id(&current_id, AppType::Codex.as_str())?
+    else {
+        return Ok(false);
+    };
+    let Some(config_text) = provider
+        .settings_config
+        .get("config")
+        .and_then(Value::as_str)
+    else {
+        return Ok(false);
+    };
+
+    crate::codex_config::ensure_codex_provider_env_ready(config_text)?;
+    Ok(crate::codex_config::extract_codex_env_key(config_text).is_some())
+}
+
 /// 统一会话开关变更后，立即按新开关状态重写当前 Codex 供应商的
 /// live 配置，使开关即时生效（无需等下一次切换）。
 pub fn reapply_current_codex_live(state: &AppState) -> Result<bool, AppError> {
@@ -1177,6 +1203,13 @@ impl ProviderService {
         Self::normalize_provider_if_claude(&app_type, &mut provider);
         if matches!(app_type, AppType::Codex) {
             normalize_codex_managed_provider_for_storage(state.db.as_ref(), &mut provider, None)?;
+            if let Some(config_text) = provider
+                .settings_config
+                .get("config")
+                .and_then(Value::as_str)
+            {
+                crate::codex_config::ensure_codex_provider_env_ready(config_text)?;
+            }
         }
         Self::validate_provider_settings(&app_type, &provider)?;
         normalize_provider_common_config_for_storage(state.db.as_ref(), &app_type, &mut provider)?;
@@ -1244,6 +1277,13 @@ impl ProviderService {
                 &mut provider,
                 Some(original_id.as_str()),
             )?;
+            if let Some(config_text) = provider
+                .settings_config
+                .get("config")
+                .and_then(Value::as_str)
+            {
+                crate::codex_config::ensure_codex_provider_env_ready(config_text)?;
+            }
         }
         Self::validate_provider_settings(&app_type, &provider)?;
         normalize_provider_common_config_for_storage(state.db.as_ref(), &app_type, &mut provider)?;
@@ -1767,6 +1807,16 @@ impl ProviderService {
             .get(id)
             .ok_or_else(|| AppError::Message(format!("供应商 {id} 不存在")))?;
         Self::validate_provider_settings(&app_type, provider)?;
+
+        if matches!(app_type, AppType::Codex) {
+            if let Some(config_text) = provider
+                .settings_config
+                .get("config")
+                .and_then(Value::as_str)
+            {
+                crate::codex_config::ensure_codex_provider_env_ready(config_text)?;
+            }
+        }
 
         Self::validate_provider_settings(&app_type, provider)?;
 

--- a/src-tauri/tests/provider_commands.rs
+++ b/src-tauri/tests/provider_commands.rs
@@ -2,8 +2,9 @@ use serde_json::json;
 
 use tuzi_switch_lib::{
     clear_provider_live_config_test_hook, get_codex_config_path, import_default_config_test_hook,
-    read_json_file, save_codex_route_test_hook, switch_provider_test_hook, write_codex_live_atomic,
-    AppError, AppType, McpApps, McpServer, MultiAppConfig, Provider, ProviderService,
+    read_json_file, save_codex_route_test_hook, switch_provider_test_hook, write_codex_env_key,
+    write_codex_live_atomic, AppError, AppType, McpApps, McpServer, MultiAppConfig, Provider,
+    ProviderService,
 };
 
 #[path = "support.rs"]
@@ -891,6 +892,45 @@ trust_level = "untrusted"
 }
 
 #[test]
+fn save_codex_route_missing_env_key_does_not_overwrite_live_config() {
+    let _guard = test_mutex().lock().expect("acquire test mutex");
+    reset_test_fs();
+    let _home = ensure_test_home();
+
+    let existing_live_config = r#"model_provider = "existing"
+model = "gpt-5.5"
+
+[model_providers.existing]
+name = "Existing"
+base_url = "https://existing.example/v1"
+wire_api = "responses"
+requires_openai_auth = false
+"#;
+    write_codex_live_atomic(&json!({}), Some(existing_live_config))
+        .expect("seed existing live config");
+    let state = create_test_state().expect("create test state");
+
+    let error = save_codex_route_test_hook(
+        &state,
+        "missing".to_string(),
+        "https://missing.example/v1".to_string(),
+        "MISSING_ROUTE_CODEX_API_KEY".to_string(),
+        String::new(),
+        "gpt-5.5".to_string(),
+        "high".to_string(),
+        Some("Missing".to_string()),
+        None,
+        None,
+    )
+    .expect_err("save should fail without env-backed key");
+    assert!(error.contains("MISSING_ROUTE_CODEX_API_KEY"));
+    assert_eq!(
+        std::fs::read_to_string(get_codex_config_path()).expect("read unchanged live config"),
+        existing_live_config
+    );
+}
+
+#[test]
 fn switch_provider_updates_codex_live_and_state() {
     let _guard = test_mutex().lock().expect("acquire test mutex");
     reset_test_fs();
@@ -974,6 +1014,8 @@ command = "say"
     );
 
     let app_state = create_test_state_with_config(&config).expect("create test state");
+    write_codex_env_key("FRESH_CODEX_API_KEY".to_string(), "fresh-key".to_string())
+        .expect("seed selected provider env key");
 
     switch_provider_test_hook(&app_state, AppType::Codex, "new-provider")
         .expect("switch provider should succeed");

--- a/src-tauri/tests/provider_service.rs
+++ b/src-tauri/tests/provider_service.rs
@@ -1,8 +1,8 @@
 use serde_json::json;
 
 use tuzi_switch_lib::{
-    get_claude_settings_path, read_json_file, write_codex_live_atomic, AppError, AppType, McpApps,
-    McpServer, MultiAppConfig, Provider, ProviderMeta, ProviderService,
+    get_claude_settings_path, read_json_file, write_codex_env_key, write_codex_live_atomic,
+    AppError, AppType, McpApps, McpServer, MultiAppConfig, Provider, ProviderMeta, ProviderService,
 };
 
 #[path = "support.rs"]
@@ -182,6 +182,8 @@ command = "say"
     );
 
     let state = create_test_state_with_config(&initial_config).expect("create test state");
+    write_codex_env_key("FRESH_CODEX_API_KEY".to_string(), "fresh-key".to_string())
+        .expect("seed selected provider env key");
 
     ProviderService::switch(&state, AppType::Codex, "new-provider")
         .expect("switch provider should succeed");
@@ -1004,6 +1006,10 @@ command = "echo"
     }
 
     let state = create_test_state_with_config(&initial_config).expect("create test state");
+    write_codex_env_key("CODING01_CODEX_API_KEY".to_string(), "test-key".to_string())
+        .expect("seed provider env key");
+    write_codex_env_key("CODING02_CODEX_API_KEY".to_string(), "test-key".to_string())
+        .expect("seed normalized provider env key");
     let provider = Provider::with_id(
         "new-provider".to_string(),
         "codex订阅-我的线路".to_string(),
@@ -1035,13 +1041,15 @@ requires_openai_auth = false
         Some("rightcode"),
         "adding a non-current Codex provider must not switch the active provider"
     );
-    assert!(
-        parsed
-            .get("model_providers")
-            .and_then(|v| v.get("codex_sub"))
-            .is_some(),
-        "main config.toml should include the newly added provider"
-    );
+    let registered_route_id = parsed
+        .get("model_providers")
+        .and_then(|value| value.as_table())
+        .and_then(|providers| {
+            providers
+                .keys()
+                .find(|route_id| route_id.starts_with("provider-coding"))
+        })
+        .expect("main config.toml should include the numbered Coding provider");
     assert!(
         config_text.contains("[mcp_servers.keep]"),
         "existing Codex config sections should be preserved"
@@ -1050,7 +1058,7 @@ requires_openai_auth = false
     let profile_path = home.join(".codex").join("codex订阅-我的线路.config.toml");
     let profile_text = std::fs::read_to_string(profile_path).expect("read codex profile");
     assert!(
-        profile_text.contains("[model_providers.codex_sub]"),
+        profile_text.contains(&format!("[model_providers.{registered_route_id}]")),
         "Codex profile config should be created for the provider"
     );
 }
@@ -1078,6 +1086,8 @@ requires_openai_auth = false
     .expect("seed codex config");
 
     let state = create_test_state().expect("create test state");
+    write_codex_env_key("CODING02_CODEX_API_KEY".to_string(), "test-key".to_string())
+        .expect("seed provider env key");
     let provider = Provider::with_id(
         "new-provider".to_string(),
         "New Provider".to_string(),
@@ -1110,8 +1120,14 @@ X-Custom-Trace = "keep-me"
     let parsed: toml::Value = toml::from_str(&config_text).expect("parse config");
     let provider = parsed
         .get("model_providers")
-        .and_then(|value| value.get("codex_sub"))
-        .expect("codex_sub provider should be registered");
+        .and_then(|value| value.as_table())
+        .and_then(|providers| {
+            providers
+                .iter()
+                .find(|(route_id, _)| route_id.starts_with("provider-coding"))
+                .map(|(_, provider)| provider)
+        })
+        .expect("numbered Coding provider should be registered");
 
     assert_eq!(
         provider
@@ -1175,6 +1191,8 @@ requires_openai_auth = false
     write_codex_live_atomic(&json!({}), Some(existing_config)).expect("seed codex config");
 
     let state = create_test_state().expect("create test state");
+    write_codex_env_key("TUZI01_CODEX_API_KEY".to_string(), "test-key".to_string())
+        .expect("seed provider env key");
     let provider = Provider::with_id(
         "new-tuzi".to_string(),
         "兔子线路-我的配置".to_string(),
@@ -1933,6 +1951,78 @@ fn provider_service_switch_codex_missing_auth_returns_error() {
         ),
         other => panic!("expected config error, got {other:?}"),
     }
+}
+
+#[test]
+fn provider_service_switch_codex_missing_env_key_preserves_current_and_live_config() {
+    let _guard = test_mutex().lock().expect("acquire test mutex");
+    reset_test_fs();
+    let _home = ensure_test_home();
+
+    let live_config = r#"model_provider = "working"
+model = "gpt-5.5"
+
+[model_providers.working]
+name = "Working"
+base_url = "https://working.example/v1"
+wire_api = "responses"
+requires_openai_auth = false
+"#;
+    write_codex_live_atomic(&json!({}), Some(live_config)).expect("seed live config");
+
+    let mut config = MultiAppConfig::default();
+    {
+        let manager = config
+            .get_manager_mut(&AppType::Codex)
+            .expect("codex manager");
+        manager.current = "working".to_string();
+        manager.providers.insert(
+            "working".to_string(),
+            Provider::with_id(
+                "working".to_string(),
+                "Working".to_string(),
+                json!({"auth": {}, "config": live_config}),
+                None,
+            ),
+        );
+        manager.providers.insert(
+            "missing-key".to_string(),
+            Provider::with_id(
+                "missing-key".to_string(),
+                "Missing Key".to_string(),
+                json!({
+                    "auth": {},
+                    "config": r#"model_provider = "missing"
+[model_providers.missing]
+name = "Missing"
+base_url = "https://missing.example/v1"
+env_key = "MISSING_SWITCH_CODEX_API_KEY"
+wire_api = "responses"
+requires_openai_auth = false
+"#
+                }),
+                None,
+            ),
+        );
+    }
+    let state = create_test_state_with_config(&config).expect("create test state");
+
+    let error = ProviderService::switch(&state, AppType::Codex, "missing-key")
+        .expect_err("switch should fail when provider key is missing");
+    assert!(error.to_string().contains("MISSING_SWITCH_CODEX_API_KEY"));
+    assert_eq!(
+        state
+            .db
+            .get_current_provider(AppType::Codex.as_str())
+            .expect("read current provider")
+            .as_deref(),
+        Some("working")
+    );
+    assert_eq!(
+        std::fs::read_to_string(tuzi_switch_lib::get_codex_config_path())
+            .expect("read unchanged live config"),
+        live_config
+    );
 }
 
 #[test]


### PR DESCRIPTION
## 问题背景

修复 Tuzi Switch 或 Codex 在 macOS 重启后、以及通过 Finder、Dock 等桌面方式启动时，Codex 供应商凭据无法读取的问题。

根因是 macOS 图形界面启动的应用不会可靠继承交互式 Shell 启动文件中导出的环境变量。供应商配置虽然仍然引用对应的 `env_key`，但桌面端 Codex 在冷启动后无法取得该 Key 的值，最终导致当前供应商配置不可用。

## 修复内容

- 将基于环境变量的 Codex 供应商凭据持久化到 `~/.codex/.env`。
- Unix 系统下为该文件设置私有权限。
- 读取受管凭据时优先使用 Codex 的 `.env` 副本。
- 应用启动时，将现有 Shell 配置中的 Key 自动迁移到 `~/.codex/.env`。
- 在添加、更新、切换供应商以及写入 Codex 路由前校验凭据是否可用。
- 当前供应商凭据不可用时，跳过启动阶段的 live 配置重放。
- 目标供应商缺少 Key 时，不改变当前供应商，也不覆盖正在使用的 `config.toml`。
- 深链导入时，先按照规范化后的最终 `env_key` 写入凭据，再执行供应商校验和保存。
- 深链导入后续失败时，恢复该环境变量原来的值；原来不存在则删除本次新增值。
- 用户明确删除受管 Key 时，同时删除 Codex `.env` 中对应的副本。

## 安全与行为边界

- API Key 明文不会写入供应商 `config.toml`。
- 原有 Shell 配置继续作为兼容迁移来源。
- 空值、包含换行符的值以及不合法的环境变量名会被拒绝。
- 缺少或为空的 Key 会返回本地化错误，并明确指出缺少的 `env_key`。
- 所有凭据校验均发生在 live 配置写入之前，避免可用配置被不可用配置覆盖。
- `.env` 使用原子写入，降低异常中断导致文件损坏的风险。

## 本地验证

在 macOS、Rust 1.95 环境下完成以下验证：

- `cargo test --lib codex_config -- --test-threads=1`：48 项相关单元测试全部通过。
- `cargo test --test provider_commands -- --test-threads=1`：15/15 通过。
- `cargo test --test deeplink_import -- --test-threads=1`：4/4 通过。
- 新增回归测试：切换到缺少环境变量 Key 的 Codex 供应商时操作失败，同时保持当前供应商标记和 live 配置文件内容不变。
- Codex 供应商添加、规范化、配置回填以及缺失 Key 切换等相关测试均已单独验证通过。
- `cargo fmt` 和 `git diff --check` 通过。

## 上游基线说明

当前上游 `main` 在提交 `ecd9625a` 上已经存在以下 3 个与本 PR 无关的测试断言失败。均已在未修改代码的独立 worktree 中复现：

- `provider_service_clear_codex_config_removes_live_route_profile_env_and_card_config`
- `provider_service_switch_codex_updates_live_and_config`
- `provider_service_switch_codex_preserves_live_model_provider_id_for_history`

具体情况：

- 第一项测试期待清除当前供应商标记，但上游现有实现会保留该标记。
- 第二项测试期待 live `config.toml` 保留 `env_key`，但上游现有实现会主动移除该字段。
- 第三项测试期待 live 配置使用选中的供应商 ID，但上游统一会话逻辑会使用共享的 `tuziswitch` 路由。

本 PR 不修改上述无关行为，避免扩大修复范围。
